### PR TITLE
fix: 修复 Android 键盘弹出时出现空白页面的问题

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,3 +2,7 @@ org.gradle.jvmargs=-Xmx4096M -Dfile.encoding=UTF-8
 android.useAndroidX=true
 android.enableJetifier=true
 org.gradle.vfs.watch=false
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/lib/routes/app_router.dart
+++ b/lib/routes/app_router.dart
@@ -379,14 +379,17 @@ class _MainShellState extends State<MainShell> {
     return NotificationListener<ScrollNotification>(
       onNotification: _onScrollNotification,
       child: Scaffold(
-        body: MediaQuery(
-          data: mediaQuery.copyWith(
-            padding: mediaQuery.padding.copyWith(
-              bottom: mediaQuery.padding.bottom + tabHeight,
-            ),
-          ),
-          child: widget.navigationShell,
-        ),
+        resizeToAvoidBottomInset: true, // 显式设置以确保键盘正确处理
+        body: isKeyboardVisible
+            ? widget.navigationShell // 键盘显示时不修改 MediaQuery，让系统自动处理
+            : MediaQuery(
+                data: mediaQuery.copyWith(
+                  padding: mediaQuery.padding.copyWith(
+                    bottom: mediaQuery.padding.bottom + tabHeight,
+                  ),
+                ),
+                child: widget.navigationShell,
+              ),
         bottomNavigationBar: const SizedBox.shrink(),
         floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
         floatingActionButton: showFloatingTabBar

--- a/lib/ui/screens/server/add_server_screen.dart
+++ b/lib/ui/screens/server/add_server_screen.dart
@@ -71,10 +71,10 @@ class _AddServerScreenState extends ConsumerState<AddServerScreen> with SingleTi
   }
   
   Widget _buildManualTab() {
-    final bottomInset = MediaQuery.of(context).viewInsets.bottom;
+    // 使用固定的 bottom padding，让 SingleChildScrollView 自动处理键盘
     return SingleChildScrollView(
       padding: const EdgeInsets.all(16).copyWith(
-        bottom: bottomInset > 0 ? bottomInset + 24 : 100,
+        bottom: 100,
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -149,10 +149,10 @@ class _AddServerScreenState extends ConsumerState<AddServerScreen> with SingleTi
   }
   
   Widget _buildBatchTab() {
-    final bottomInset = MediaQuery.of(context).viewInsets.bottom;
+    // 使用固定的 bottom padding，让 SingleChildScrollView 自动处理键盘
     return SingleChildScrollView(
       padding: const EdgeInsets.all(16).copyWith(
-        bottom: bottomInset > 0 ? bottomInset + 24 : 100,
+        bottom: 100,
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -236,11 +236,10 @@ class _AddServerScreenState extends ConsumerState<AddServerScreen> with SingleTi
   }
   
   Widget _buildImportTab() {
-    final bottomInset = MediaQuery.of(context).viewInsets.bottom;
-    
+    // 使用固定的 bottom padding，让 SingleChildScrollView 自动处理键盘
     return SingleChildScrollView(
       padding: const EdgeInsets.all(16).copyWith(
-        bottom: bottomInset > 0 ? bottomInset + 24 : 100,
+        bottom: 100,
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,


### PR DESCRIPTION
## 问题描述

在 Android 端，无论在哪个界面，只要键盘打开，就会出现一个空白页面挡住其他显示内容。

## 根本原因

1. **MainShell 的 MediaQuery 修改冲突**：即使在键盘显示时 tabHeight = 0，MediaQuery.copyWith 操作本身也会与 Android 系统的 window insets 处理机制产生冲突，导致布局计算错误。

2. **过度的 bottom padding 计算**：add_server_screen 中手动将 viewInsets.bottom（键盘高度 300-400px）加到 SingleChildScrollView 的 padding，导致双重计算和过度间距。

## 修复方案

### 1. 修复 MainShell (`lib/routes/app_router.dart`)
- 键盘显示时不修改 MediaQuery，让系统自动处理 insets
- 键盘隐藏时才为浮动 tab bar 增加底部 padding
- 显式设置 `resizeToAvoidBottomInset: true` 确保行为一致

### 2. 修复 add_server_screen (`lib/ui/screens/server/add_server_screen.dart`)
- 移除三个 tab 中手动的 `viewInsets.bottom` 计算
- 使用固定的 bottom padding (100px)
- 让 SingleChildScrollView 自动处理键盘的 insets

### 3. 更新 Gradle 配置
- 添加 Flutter 迁移标记到 gradle.properties

## 测试验证

✅ 已在 Android 设备上测试通过：
- 添加服务器页面的所有输入框
- 键盘弹出时不再出现空白页面
- 输入框可见且可以正常输入
- 浮动 tab bar 在键盘显示/隐藏时行为正常

## 影响范围

- **全局**：MainShell 的修改影响所有页面的键盘行为
- **局部**：add_server_screen 的修改仅影响服务器添加页面

## 文件变更

- `lib/routes/app_router.dart` - 修复 MainShell 的 MediaQuery 处理
- `lib/ui/screens/server/add_server_screen.dart` - 修复三个 tab 的 padding 计算  
- `android/gradle.properties` - 添加 Flutter 迁移标记

## Checklist

- [x] 代码通过 flutter analyze
- [x] 在 Android 设备上测试通过
- [x] 修复了核心问题，没有引入新问题
- [x] 遵循项目编码规范