### PR TITLE
fix: text readability on dark dynamic backgrounds

### DIFF
--- a/lib/routes/app_router.dart
+++ b/lib/routes/app_router.dart
@@ -164,6 +164,7 @@ final appRouterProvider = Provider<GoRouter>((ref) {
         path: '/season/:id',
         builder: (context, state) => SeasonDetailScreen(
           seasonId: state.pathParameters['id']!,
+          backgroundColor: state.extra is Color ? state.extra as Color : null,
         ),
       ),
       GoRoute(

--- a/lib/ui/screens/detail/media_detail_screen.dart
+++ b/lib/ui/screens/detail/media_detail_screen.dart
@@ -9,6 +9,7 @@ import '../../../core/utils/color_extractor.dart';
 import '../../../core/utils/platform_utils.dart';
 import '../../screens/download/download_screen.dart';
 import '../../utils/media_helpers.dart';
+import '../../widgets/common/dynamic_background.dart';
 import '../../widgets/common/media_widgets.dart';
 import '../../widgets/common/playback_options.dart';
 import '../../widgets/common/video_background.dart';
@@ -62,13 +63,8 @@ class _DetailContentState extends State<_DetailContent> {
     final foregroundColor = readableTextColorForBackground(_backgroundColor);
     return Scaffold(
       backgroundColor: _backgroundColor,
-      body: Theme(
-        data: Theme.of(context).copyWith(
-          textTheme: Theme.of(context).textTheme.apply(
-                bodyColor: foregroundColor,
-                displayColor: foregroundColor,
-              ),
-        ),
+      body: DynamicBackground(
+        backgroundColor: _backgroundColor,
         child: CustomScrollView(
         slivers: [
           // 封面区域
@@ -94,7 +90,7 @@ class _DetailContentState extends State<_DetailContent> {
               child: _SeasonsAndEpisodesSection(
                 itemId: widget.itemId,
                 onEpisodeTap: (episode) => context.push('/episode/${episode.id}'),
-                onSeasonTap: (season) => context.push('/season/${season.id}'),
+                onSeasonTap: (season) => context.push('/season/${season.id}', extra: _backgroundColor),
               ),
             ),
           ],
@@ -726,6 +722,7 @@ class _EpisodeListTile extends ConsumerWidget {
           Expanded(
             child: Text(
               'E${episode.indexNumber} ${episode.name}',
+              style: TextStyle(color: Theme.of(context).textTheme.bodyLarge?.color ?? Colors.white),
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
             ),
@@ -820,10 +817,12 @@ class _MoviePlayButtons extends ConsumerWidget {
     final api = ref.read(apiClientProvider);
     showModalBottomSheet(
       context: context,
-      builder: (context) => SafeArea(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
+      builder: (context) => DefaultTextStyle.merge(
+        style: TextStyle(color: Theme.of(context).textTheme.bodyLarge?.color),
+        child: SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
             ListTile(
               leading: const Icon(Icons.cast),
               title: const Text('投屏'),
@@ -902,6 +901,7 @@ class _MoviePlayButtons extends ConsumerWidget {
           ],
         ),
       ),
+      ),
     );
   }
 
@@ -942,8 +942,10 @@ class _MoviePlayButtons extends ConsumerWidget {
     
     showDialog(
       context: context,
-      builder: (context) => AlertDialog(
-        title: Row(
+      builder: (context) => DefaultTextStyle.merge(
+        style: TextStyle(color: Theme.of(context).textTheme.bodyLarge?.color),
+        child: AlertDialog(
+          title: Row(
           children: [
             const Text('投屏设备'),
             const Spacer(),
@@ -999,8 +1001,9 @@ class _MoviePlayButtons extends ConsumerWidget {
           ),
         ],
       ),
+      ),
     );
-    
+
     // 开始扫描
     castService.startDiscovery();
   }

--- a/lib/ui/screens/detail/season_detail_screen.dart
+++ b/lib/ui/screens/detail/season_detail_screen.dart
@@ -9,6 +9,7 @@ import '../../../core/utils/color_extractor.dart';
 import '../../../core/utils/platform_utils.dart';
 import '../../screens/download/download_screen.dart';
 import '../../utils/media_helpers.dart';
+import '../../widgets/common/dynamic_background.dart';
 import '../../widgets/common/media_widgets.dart';
 import '../../widgets/common/playback_options.dart';
 import '../../widgets/common/video_background.dart';
@@ -16,8 +17,13 @@ import '../../widgets/common/video_background.dart';
 /// 季详情页
 class SeasonDetailScreen extends ConsumerStatefulWidget {
   final String seasonId;
+  final Color? backgroundColor;
 
-  const SeasonDetailScreen({super.key, required this.seasonId});
+  const SeasonDetailScreen({
+    super.key,
+    required this.seasonId,
+    this.backgroundColor,
+  });
 
   @override
   ConsumerState<SeasonDetailScreen> createState() => _SeasonDetailScreenState();
@@ -59,73 +65,77 @@ class _SeasonDetailScreenState extends ConsumerState<SeasonDetailScreen> {
   Widget build(BuildContext context) {
     final api = ref.read(apiClientProvider);
 
-    if (_seriesId == null) {
-      return Scaffold(
-        appBar: AppBar(title: Text(_seasonName ?? '季详情')),
-        body: const Center(child: CircularProgressIndicator()),
-      );
-    }
-
-    final episodesAsync = ref.watch(episodesProvider((seriesId: _seriesId!, seasonId: widget.seasonId)));
-
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(_seasonName ?? '季详情'),
+    return DynamicBackground(
+      backgroundColor: widget.backgroundColor ?? const Color(0xFF121212),
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text(_seasonName ?? '季详情'),
+        ),
+        body: _seriesId == null
+            ? const Center(child: CircularProgressIndicator())
+            : _buildEpisodeList(api),
       ),
-      body: episodesAsync.when(
-        data: (episodes) {
-          if (episodes.isEmpty) {
-            return const Center(child: Text('暂无集数'));
-          }
-          return ListView.builder(
-            padding: const EdgeInsets.all(16),
-            itemCount: episodes.length,
-            itemBuilder: (context, index) {
-              final episode = episodes[index];
-              final imageUrls = resolveEpisodeLandscapeImageUrls(
-                api,
-                episode,
-                maxWidth: 480,
-              );
-              return Card(
-                margin: const EdgeInsets.only(bottom: 12),
-                child: ListTile(
-                  onTap: () => context.push('/episode/${episode.id}'),
-                  leading: ClipRRect(
-                    borderRadius: BorderRadius.circular(8),
-                    child: Container(
-                      width: 100,
-                      height: 60,
-                      color: Theme.of(context).colorScheme.surfaceContainerHighest,
-                      child: imageUrls.isNotEmpty
-                          ? MediaImage(
-                              imageUrl: imageUrls.first,
-                              imageUrls: imageUrls.length > 1
-                                  ? imageUrls.sublist(1)
-                                  : null,
-                              width: 100,
-                              height: 60,
-                              fit: BoxFit.cover,
-                            )
-                          : const Center(child: Icon(Icons.play_arrow)),
-                    ),
+    );
+  }
+
+  Widget _buildEpisodeList(ApiClientFactory api) {
+    final episodesAsync = ref.watch(
+      episodesProvider((seriesId: _seriesId!, seasonId: widget.seasonId)),
+    );
+
+    return episodesAsync.when(
+      data: (episodes) {
+        if (episodes.isEmpty) {
+          return const Center(child: Text('暂无集数'));
+        }
+        return ListView.builder(
+          padding: const EdgeInsets.all(16),
+          itemCount: episodes.length,
+          itemBuilder: (context, index) {
+            final episode = episodes[index];
+            final imageUrls = resolveEpisodeLandscapeImageUrls(
+              api,
+              episode,
+              maxWidth: 480,
+            );
+            return Card(
+              margin: const EdgeInsets.only(bottom: 12),
+              child: ListTile(
+                onTap: () => context.push('/episode/${episode.id}'),
+                leading: ClipRRect(
+                  borderRadius: BorderRadius.circular(8),
+                  child: Container(
+                    width: 100,
+                    height: 60,
+                    color: Theme.of(context).colorScheme.surfaceContainerHighest,
+                    child: imageUrls.isNotEmpty
+                        ? MediaImage(
+                            imageUrl: imageUrls.first,
+                            imageUrls: imageUrls.length > 1
+                                ? imageUrls.sublist(1)
+                                : null,
+                            width: 100,
+                            height: 60,
+                            fit: BoxFit.cover,
+                          )
+                        : const Center(child: Icon(Icons.play_arrow)),
                   ),
-                  title: Text('E${episode.indexNumber} ${episode.name}'),
-                  subtitle: Text(
-                    episode.formattedRuntime ?? '',
-                    style: TextStyle(color: Theme.of(context).textTheme.bodySmall?.color),
-                  ),
-                  trailing: episode.userData?.played ?? false
-                      ? const Icon(Icons.check_circle, color: Color(0xFF5B8DEF))
-                      : null,
                 ),
-              );
-            },
-          );
-        },
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error: (error, _) => Center(child: Text('错误: $error')),
-      ),
+                title: Text('E${episode.indexNumber} ${episode.name}'),
+                subtitle: Text(
+                  episode.formattedRuntime ?? '',
+                  style: TextStyle(color: Theme.of(context).textTheme.bodySmall?.color),
+                ),
+                trailing: episode.userData?.played ?? false
+                    ? const Icon(Icons.check_circle, color: Color(0xFF5B8DEF))
+                    : null,
+              ),
+            );
+          },
+        );
+      },
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (error, _) => Center(child: Text('错误: $error')),
     );
   }
 }
@@ -181,13 +191,8 @@ class _EpisodeDetailScreenState extends ConsumerState<EpisodeDetailScreen> {
     return Scaffold(
       backgroundColor: _backgroundColor,
       body: itemAsync.when(
-        data: (item) => Theme(
-          data: Theme.of(context).copyWith(
-            textTheme: Theme.of(context).textTheme.apply(
-                  bodyColor: foregroundColor,
-                  displayColor: foregroundColor,
-                ),
-          ),
+        data: (item) => DynamicBackground(
+          backgroundColor: _backgroundColor,
           child: CustomScrollView(
           slivers: [
             // 封面区域

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -6,6 +6,7 @@ import '../../../core/api/api_interfaces.dart';
 import '../../../core/providers/media_providers.dart';
 import '../../../core/utils/color_extractor.dart';
 import '../../utils/media_helpers.dart';
+import '../../widgets/common/dynamic_background.dart';
 import '../../widgets/common/media_widgets.dart';
 
 /// 首页构建性能优化
@@ -78,60 +79,53 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
     final currentServer = ref.watch(currentServerProvider);
     final hideDailyRecommendations = ref.watch(hideDailyRecommendationsProvider);
     final recommendationsAsync = ref.watch(randomRecommendationsProvider);
-    final foregroundColor = readableTextColorForBackground(_backgroundColor);
-
     return Scaffold(
       backgroundColor: _backgroundColor,
-      body: Theme(
-        data: Theme.of(context).copyWith(
-          textTheme: Theme.of(context).textTheme.apply(
-                bodyColor: foregroundColor,
-                displayColor: foregroundColor,
-              ),
-        ),
+      body: DynamicBackground(
+        backgroundColor: _backgroundColor,
         child: Stack(
-          children: [
-            CustomScrollView(
-              controller: _scrollController,
-              slivers: [
-                // 随机推荐轮播（可被隐藏）- 直接顶到最上方
-                if (!hideDailyRecommendations)
-                  SliverToBoxAdapter(
-                    child: RandomRecommendationCarousel(
-                      onColorChanged: _onBackgroundColorChanged,
+            children: [
+              CustomScrollView(
+                controller: _scrollController,
+                slivers: [
+                  // 随机推荐轮播（可被隐藏）- 直接顶到最上方
+                  if (!hideDailyRecommendations)
+                    SliverToBoxAdapter(
+                      child: RandomRecommendationCarousel(
+                        onColorChanged: _onBackgroundColorChanged,
+                      ),
                     ),
-                  ),
 
-                // 继续观看
-                const SliverToBoxAdapter(child: ContinueWatchingSection()),
+                  // 继续观看
+                  const SliverToBoxAdapter(child: ContinueWatchingSection()),
 
-                // 媒体库
-                const SliverToBoxAdapter(child: LibrariesSection()),
+                  // 媒体库
+                  const SliverToBoxAdapter(child: LibrariesSection()),
 
-                // 各媒体库最新内容
-                const SliverToBoxAdapter(child: LatestItemsSections()),
+                  // 各媒体库最新内容
+                  const SliverToBoxAdapter(child: LatestItemsSections()),
 
-                const SliverPadding(padding: EdgeInsets.only(bottom: 32)),
-              ],
-            ),
-            // 顶部栏（悬浮，透明背景）
-            Positioned(
-              top: 0,
-              left: 0,
-              right: 0,
-              child: AnimatedOpacity(
-                opacity: _appBarOpacity,
-                duration: const Duration(milliseconds: 150),
-                child: _HomeAppBar(
-                  serverName: currentServer?.name ?? '服务器',
-                  backgroundImage: recommendationsAsync.when(
-                    data: (items) => items.isNotEmpty ? items.first : null,
-                    loading: () => null,
-                    error: (_, __) => null,
+                  const SliverPadding(padding: EdgeInsets.only(bottom: 32)),
+                ],
+              ),
+              // 顶部栏（悬浮，透明背景）
+              Positioned(
+                top: 0,
+                left: 0,
+                right: 0,
+                child: AnimatedOpacity(
+                  opacity: _appBarOpacity,
+                  duration: const Duration(milliseconds: 150),
+                  child: _HomeAppBar(
+                    serverName: currentServer?.name ?? '服务器',
+                    backgroundImage: recommendationsAsync.when(
+                      data: (items) => items.isNotEmpty ? items.first : null,
+                      loading: () => null,
+                      error: (_, __) => null,
+                    ),
                   ),
                 ),
               ),
-            ),
           ],
         ),
       ),
@@ -1394,7 +1388,7 @@ class _LibraryLatestSection extends ConsumerWidget {
               ),
             ),
             HorizontalList(
-              height: 200,
+              height: 240,
               children: items.map((item) {
                 return SizedBox(
                   width: 120,

--- a/lib/ui/widgets/common/dynamic_background.dart
+++ b/lib/ui/widgets/common/dynamic_background.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import '../../utils/media_helpers.dart';
+
+/// 动态背景包装器 — 确保内容文字在提取的深色背景上始终可读。
+///
+/// 同时设置五维：
+/// 1. [Theme] `brightness: Brightness.dark` — 让 Material 组件走暗色路径
+/// 2. [Theme] `colorScheme` — 基于品牌色生成暗色 variant，确保 surface/onSurface 正确
+/// 3. [Theme] `textTheme.apply()` — 让显式读取主题颜色的 widget 拿到前景色
+/// 4. [Theme] `iconTheme` — 让 Icon/IconButton 图标可见
+/// 5. [DefaultTextStyle.merge] — 让不含显式颜色的 [Text] widget 继承前景色
+class DynamicBackground extends StatelessWidget {
+  final Color backgroundColor;
+  final Widget child;
+
+  const DynamicBackground({
+    required this.backgroundColor,
+    required this.child,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final parentTheme = Theme.of(context);
+    final foregroundColor = readableTextColorForBackground(backgroundColor);
+    final darkScheme = ColorScheme.fromSeed(
+      seedColor: parentTheme.colorScheme.primary,
+      brightness: Brightness.dark,
+    );
+    return DefaultTextStyle.merge(
+      style: TextStyle(color: foregroundColor),
+      child: Theme(
+        data: parentTheme.copyWith(
+          brightness: Brightness.dark,
+          colorScheme: darkScheme,
+          scaffoldBackgroundColor: backgroundColor,
+          cardTheme: parentTheme.cardTheme.copyWith(color: darkScheme.surface),
+          textTheme: parentTheme.textTheme.apply(
+                bodyColor: foregroundColor,
+                displayColor: foregroundColor,
+              ),
+          iconTheme: parentTheme.iconTheme.copyWith(
+                color: foregroundColor,
+              ),
+          appBarTheme: parentTheme.appBarTheme.copyWith(
+                backgroundColor: backgroundColor,
+                foregroundColor: foregroundColor,
+                titleTextStyle: parentTheme.appBarTheme.titleTextStyle?.copyWith(
+                  color: foregroundColor,
+                ),
+              ),
+        ),
+        child: child,
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Problem

On Android light mode, screens with dynamic dark backgrounds (from image color extraction) had invisible text. Theme overlay only updates Theme.of(context).textTheme but not DefaultTextStyle — uncolored Text widgets inherited dark text from the root light theme, invisible against dark extracted backgrounds.

## Solution

Created a **DynamicBackground** widget that combines:
- DefaultTextStyle.merge — ensures all plain Text widgets get the correct foreground color
- Theme(brightness: dark) + ColorScheme.fromSeed — forces Material components to dark path
- AppBarTheme, CardTheme, IconTheme — fixes sub-theme colors

Applied to: HomeScreen, MediaDetailScreen, EpisodeDetailScreen, SeasonDetailScreen.

SeasonDetailScreen inherits parent background color via GoRouter extra for visual consistency.

### Files
- **New:** lib/ui/widgets/common/dynamic_background.dart
- lib/ui/screens/home/home_screen.dart
- lib/ui/screens/detail/media_detail_screen.dart
- lib/ui/screens/detail/season_detail_screen.dart
- lib/routes/app_router.dart