### PR TITLE
fix: 修复 Riverpod 生命周期错误

### DIFF
--- a/lib/ui/screens/detail/season_detail_screen.dart
+++ b/lib/ui/screens/detail/season_detail_screen.dart
@@ -166,10 +166,12 @@ class _EpisodeDetailScreenState extends ConsumerState<EpisodeDetailScreen> {
   }
 
   void _resetPlaybackSelections() {
-    ref.read(selectedMediaSourceProvider.notifier).state = null;
-    ref.read(audioTrackProvider.notifier).state = null;
-    ref.read(subtitleTrackProvider.notifier).state = null;
-    ref.read(secondarySubtitleTrackProvider.notifier).state = null;
+    Future.microtask(() {
+      ref.read(selectedMediaSourceProvider.notifier).state = null;
+      ref.read(audioTrackProvider.notifier).state = null;
+      ref.read(subtitleTrackProvider.notifier).state = null;
+      ref.read(secondarySubtitleTrackProvider.notifier).state = null;
+    });
   }
 
   Color _backgroundColor = const Color(0xFF121212);


### PR DESCRIPTION
## 问题描述

应用在导航至剧集详情页时崩溃，错误信息：
```
Tried to modify a provider while the widget tree was building.
```

## 根本原因

`_EpisodeDetailScreenState._resetPlaybackSelections()` 方法在 `initState()` 和 `didUpdateWidget()` 中直接修改了四个 Riverpod providers：
- `selectedMediaSourceProvider`
- `audioTrackProvider`
- `subtitleTrackProvider`
- `secondarySubtitleTrackProvider`

这些生命周期方法在 widget 构建阶段执行，Riverpod 禁止在此期间修改 provider 以防止 UI 状态不一致。

## 解决方案

使用 `Future.microtask()` 将 provider 修改操作延迟到当前同步代码执行完成后。这是 Riverpod 官方推荐的在生命周期方法中初始化 provider 状态的标准模式。

## 修改内容

- **文件**：`lib/ui/screens/detail/season_detail_screen.dart`
- **方法**：`_resetPlaybackSelections()` (第 168-175 行)

将直接的 provider 修改包装在 `Future.microtask()` 回调中。

## 测试步骤

1. 运行应用
2. 导航至：首页 → 系列 → 季 → 剧集详情页
3. 确认不再崩溃
4. 按返回键，导航至另一个剧集
5. 确认 provider 状态正确重置（没有上一个剧集的残留选择）

## 影响范围

- 仅影响 `EpisodeDetailScreen` 的初始化逻辑
- 无 API 变更
- 无功能变更，纯修复性质