### PR TITLE
feat: 首页轮播图使用艺术字 Logo 作为标题

### DIFF
--- a/apple_tv/LinPlayerTV/Models/MediaModels.swift
+++ b/apple_tv/LinPlayerTV/Models/MediaModels.swift
@@ -105,6 +105,8 @@ struct MediaItem: Codable, Identifiable, Hashable {
     let parentPrimaryImageTag: String?
     let seriesThumbImageTag: String?
     let seriesPrimaryImageTag: String?
+    let parentLogoItemId: String?
+    let parentLogoImageTag: String?
     let people: [PersonInfo]?
 
     enum CodingKeys: String, CodingKey {
@@ -135,6 +137,8 @@ struct MediaItem: Codable, Identifiable, Hashable {
         case parentPrimaryImageTag = "ParentPrimaryImageTag"
         case seriesThumbImageTag = "SeriesThumbImageTag"
         case seriesPrimaryImageTag = "SeriesPrimaryImageTag"
+        case parentLogoItemId = "ParentLogoItemId"
+        case parentLogoImageTag = "ParentLogoImageTag"
         case people = "People"
     }
 
@@ -148,6 +152,17 @@ struct MediaItem: Codable, Identifiable, Hashable {
 
     var backdropImageTag: String? {
         backdropImageTags?.first ?? imageTags?["Backdrop"]
+    }
+
+    /// 有 Logo 的项目 ID（优先自身，否则父级）
+    var logoItemId: String? {
+        if imageTags?["Logo"] != nil { return id }
+        return parentLogoItemId
+    }
+
+    /// Logo 缓存 tag（优先自身，否则父级）
+    var logoImageTag: String? {
+        imageTags?["Logo"] ?? parentLogoImageTag
     }
 
     var formattedRuntime: String? {

--- a/apple_tv/LinPlayerTV/Services/EmbyApiClient.swift
+++ b/apple_tv/LinPlayerTV/Services/EmbyApiClient.swift
@@ -17,7 +17,7 @@ final class EmbyApiClient: ObservableObject {
         "ParentIndexNumber", "ImageTags", "ParentThumbItemId", "ParentThumbImageTag",
         "ParentPrimaryImageItemId", "ParentPrimaryImageTag", "SeriesThumbImageTag",
         "SeriesPrimaryImageTag", "BackdropImageTags", "ChildCount", "RecursiveItemCount",
-        "People", "CanDownload", "SupportsSync"
+        "People", "CanDownload", "SupportsSync", "ParentLogoItemId", "ParentLogoImageTag"
     ].joined(separator: ",")
 
     init(baseURL: String, accessToken: String? = nil, userId: String? = nil) {
@@ -421,6 +421,11 @@ final class EmbyApiClient: ObservableObject {
 
     func thumbImageURL(_ itemId: String, tag: String? = nil, maxWidth: Int? = nil) -> URL? {
         imageURL(itemId: itemId, imageType: "Thumb", tag: tag, maxWidth: maxWidth)
+    }
+
+    func logoImageURL(_ itemId: String, tag: String?, maxWidth: Int? = nil) -> URL? {
+        guard tag != nil else { return nil }
+        return imageURL(itemId: itemId, imageType: "Logo", tag: tag, maxWidth: maxWidth ?? 400)
     }
 }
 

--- a/apple_tv/LinPlayerTV/Views/Components/HeroBanner.swift
+++ b/apple_tv/LinPlayerTV/Views/Components/HeroBanner.swift
@@ -25,10 +25,7 @@ struct HeroBanner: View {
                 )
 
                 VStack(alignment: .leading, spacing: AppTheme.Spacing.md) {
-                    Text(item.name)
-                        .font(.system(size: AppTheme.FontSize.title1, weight: .bold))
-                        .foregroundColor(.white)
-                        .lineLimit(2)
+                    logoOrTitle(for: item)
 
                     HStack(spacing: AppTheme.Spacing.md) {
                         if let rating = item.communityRating {
@@ -151,6 +148,36 @@ struct HeroBanner: View {
         .frame(maxWidth: .infinity)
         .frame(height: 600)
         .clipped()
+    }
+
+    /// 优先使用 Logo 艺术字图片，无 Logo 时回退到文字标题
+    @ViewBuilder
+    private func logoOrTitle(for item: MediaItem) -> some View {
+        if let logoURL = apiClient.logoImageURL(
+            item.logoItemId ?? item.id,
+            tag: item.logoImageTag
+        ) {
+            AsyncImage(url: logoURL) { phase in
+                switch phase {
+                case .success(let image):
+                    image
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(maxWidth: 300, maxHeight: 60)
+                default:
+                    titleText(item.name)
+                }
+            }
+        } else {
+            titleText(item.name)
+        }
+    }
+
+    private func titleText(_ name: String) -> some View {
+        Text(name)
+            .font(.system(size: AppTheme.FontSize.title1, weight: .bold))
+            .foregroundColor(.white)
+            .lineLimit(2)
     }
 
     private var indicators: some View {

--- a/apple_tv/LinPlayerTV/Views/Detail/DetailView.swift
+++ b/apple_tv/LinPlayerTV/Views/Detail/DetailView.swift
@@ -42,7 +42,9 @@ struct DetailView: View {
                         backdropImageTags: nil, parentThumbItemId: episode.parentThumbItemId,
                         parentThumbImageTag: episode.parentThumbImageTag,
                         parentPrimaryImageItemId: nil, parentPrimaryImageTag: nil,
-                        seriesThumbImageTag: nil, seriesPrimaryImageTag: nil, people: nil
+                        seriesThumbImageTag: nil, seriesPrimaryImageTag: nil,
+                        parentLogoItemId: nil, parentLogoImageTag: nil,
+                        people: nil
                     ),
                     apiClient: apiClient
                 )

--- a/lib/core/api/api_interfaces.dart
+++ b/lib/core/api/api_interfaces.dart
@@ -233,6 +233,8 @@ class MediaItem {
   final List<Person>? people;
   final bool? canDownload;
   final List<String>? remoteTrailers;
+  final String? logoItemId;      // 有 Logo 的项目 ID（自身或父级）
+  final String? logoImageTag;    // Logo 缓存 tag
 
   MediaItem({
     required this.id,
@@ -271,6 +273,8 @@ class MediaItem {
     this.people,
     this.canDownload,
     this.remoteTrailers,
+    this.logoItemId,
+    this.logoImageTag,
   });
 
   String? get formattedRuntime {
@@ -749,6 +753,9 @@ abstract class ImageApi {
   /// 获取背景图
   String getBackdropImageUrl(String itemId,
       {String? tag, int? maxWidth, String? format});
+
+  /// 获取 Logo 图片（艺术字标题）
+  String? getLogoImageUrl(String itemId, {String? tag, int? maxWidth});
 }
 
 // ==================== 弹幕相关 ====================

--- a/lib/core/api/emby_api.dart
+++ b/lib/core/api/emby_api.dart
@@ -335,7 +335,8 @@ class EmbyHomeApi implements HomeApi {
       'ParentIndexNumber,ImageTags,ParentThumbItemId,ParentThumbImageTag,'
       'ParentPrimaryImageItemId,ParentPrimaryImageTag,SeriesThumbImageTag,'
       'SeriesPrimaryImageTag,BackdropImageTags,ChildCount,RecursiveItemCount,'
-      'CanDownload,SupportsSync,ProviderIds,PresentationUniqueKey,Path';
+      'CanDownload,SupportsSync,ProviderIds,PresentationUniqueKey,Path,'
+      'ParentLogoItemId,ParentLogoImageTag';
 
   @override
   Future<List<MediaItem>> getResumeItems() async {
@@ -436,7 +437,8 @@ class EmbyLibraryApi implements LibraryApi {
       'ParentIndexNumber,ImageTags,ParentThumbItemId,ParentThumbImageTag,'
       'ParentPrimaryImageItemId,ParentPrimaryImageTag,SeriesThumbImageTag,'
       'SeriesPrimaryImageTag,ChildCount,RecursiveItemCount,CanDownload,SupportsSync,'
-      'ProviderIds,PresentationUniqueKey,Path';
+      'ProviderIds,PresentationUniqueKey,Path,'
+      'ParentLogoItemId,ParentLogoImageTag';
 
   @override
   Future<List<MediaItem>> getLibraryItems({
@@ -501,7 +503,8 @@ class EmbyMediaApi implements MediaApi {
       'ParentThumbImageTag,ParentPrimaryImageItemId,ParentPrimaryImageTag,'
       'SeriesThumbImageTag,SeriesPrimaryImageTag,BackdropImageTags,'
       'ChildCount,RecursiveItemCount,CanDownload,SupportsSync,ProviderIds,'
-      'PresentationUniqueKey,Path';
+      'PresentationUniqueKey,Path,'
+      'ParentLogoItemId,ParentLogoImageTag';
 
   @override
   Future<MediaItem> getItemDetails(String itemId) async {
@@ -748,7 +751,7 @@ class EmbyFavoriteApi implements FavoriteApi {
       'ParentIndexNumber,ImageTags,ParentThumbItemId,ParentThumbImageTag,'
       'ParentPrimaryImageItemId,ParentPrimaryImageTag,SeriesThumbImageTag,'
       'SeriesPrimaryImageTag,BackdropImageTags,ChildCount,RecursiveItemCount,'
-      'CanDownload,SupportsSync';
+      'CanDownload,SupportsSync,ParentLogoItemId,ParentLogoImageTag';
 
   @override
   Future<List<MediaItem>> getFavorites() async {
@@ -856,6 +859,17 @@ class EmbyImageApi implements ImageApi {
       maxWidth: maxWidth ?? 800,
       maxHeight: 450,
       format: format,
+    );
+  }
+
+  @override
+  String? getLogoImageUrl(String itemId, {String? tag, int? maxWidth}) {
+    if (tag == null || tag.isEmpty) return null;
+    return getImageUrl(
+      itemId: itemId,
+      imageTag: tag,
+      imageType: 'Logo',
+      maxWidth: maxWidth ?? 400,
     );
   }
 }
@@ -970,6 +984,8 @@ MediaItem _parseMediaItem(Map<String, dynamic> d) {
         .where((url) => url != null && url.isNotEmpty)
         .cast<String>()
         .toList(),
+    logoItemId: _extractLogoItemId(d),
+    logoImageTag: _extractLogoImageTag(d),
   );
 }
 
@@ -1000,6 +1016,25 @@ String? _extractImageTag(Map<String, dynamic> d, String type) {
   final value = tags?[type]?.toString();
   if (value == null || value.isEmpty) return null;
   return value;
+}
+
+/// 提取 Logo 项目 ID：优先使用自身，否则使用父级
+String? _extractLogoItemId(Map<String, dynamic> d) {
+  final tags = d['ImageTags'] as Map<String, dynamic>?;
+  if (tags?.containsKey('Logo') == true) {
+    return d['Id']?.toString();
+  }
+  final parentId = d['ParentLogoItemId']?.toString();
+  return (parentId != null && parentId.isNotEmpty) ? parentId : null;
+}
+
+/// 提取 Logo 缓存 tag：优先使用自身，否则使用父级
+String? _extractLogoImageTag(Map<String, dynamic> d) {
+  final tags = d['ImageTags'] as Map<String, dynamic>?;
+  final ownTag = tags?['Logo']?.toString();
+  if (ownTag != null && ownTag.isNotEmpty) return ownTag;
+  final parentTag = d['ParentLogoImageTag']?.toString();
+  return (parentTag != null && parentTag.isNotEmpty) ? parentTag : null;
 }
 
 int? _parseTicks(dynamic v) {

--- a/lib/desktop/screens/home/desktop_home_screen.dart
+++ b/lib/desktop/screens/home/desktop_home_screen.dart
@@ -1234,7 +1234,7 @@ class _DesktopCarouselState extends ConsumerState<_DesktopCarousel> {
   }
 }
 
-class _CarouselInfo extends StatelessWidget {
+class _CarouselInfo extends ConsumerWidget {
   final MediaItem item;
 
   static const List<Shadow> _titleShadows = [
@@ -1253,24 +1253,14 @@ class _CarouselInfo extends StatelessWidget {
   const _CarouselInfo({required this.item});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final api = ref.read(apiClientProvider);
     final theme = Theme.of(context);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       mainAxisSize: MainAxisSize.min,
       children: [
-        Text(
-          item.name,
-          maxLines: 2,
-          overflow: TextOverflow.ellipsis,
-          style: theme.textTheme.displaySmall?.copyWith(
-            fontWeight: FontWeight.w800,
-            color: Colors.white,
-            height: 0.96,
-            letterSpacing: -0.9,
-            shadows: _titleShadows,
-          ),
-        ),
+        _buildLogoOrTitle(api),
         const SizedBox(height: 8),
         Wrap(
           spacing: 10,
@@ -1308,6 +1298,44 @@ class _CarouselInfo extends StatelessWidget {
           ],
         ),
       ],
+    );
+  }
+
+  /// 优先使用 Logo 艺术字图片，无 Logo 时回退到文字标题
+  Widget _buildLogoOrTitle(dynamic api) {
+    final logoUrl = (item.logoItemId != null && item.logoImageTag != null)
+        ? api.image.getLogoImageUrl(item.logoItemId!, tag: item.logoImageTag, maxWidth: 280)
+        : null;
+
+    if (logoUrl != null && logoUrl.isNotEmpty) {
+      return Image.network(
+        logoUrl,
+        height: 48,
+        fit: BoxFit.contain,
+        alignment: Alignment.centerLeft,
+        errorBuilder: (_, __, ___) => _buildTitleText(),
+        frameBuilder: (_, child, frame, wasSynchronouslyLoaded) {
+          if (wasSynchronouslyLoaded || frame != null) return child;
+          return _buildTitleText();
+        },
+      );
+    }
+    return _buildTitleText();
+  }
+
+  Widget _buildTitleText() {
+    return Text(
+      item.name,
+      maxLines: 2,
+      overflow: TextOverflow.ellipsis,
+      style: const TextStyle(
+        fontSize: 28,
+        fontWeight: FontWeight.w800,
+        color: Colors.white,
+        height: 0.96,
+        letterSpacing: -0.9,
+        shadows: _titleShadows,
+      ),
     );
   }
 }

--- a/lib/tv/widgets/tv_hero_banner.dart
+++ b/lib/tv/widgets/tv_hero_banner.dart
@@ -193,14 +193,7 @@ class _TvHeroBannerState extends State<TvHeroBanner> {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Text(
-                item.title,
-                style: const TextStyle(
-                  fontSize: TvDesignTokens.heroTitleSize,
-                  color: TvDesignTokens.textPrimary,
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
+              _buildLogoOrTitle(item),
               if (item.subtitle != null) ...[
                 const SizedBox(height: TvDesignTokens.spacingSm),
                 Text(
@@ -278,6 +271,35 @@ class _TvHeroBannerState extends State<TvHeroBanner> {
     );
   }
 
+  /// 优先使用 Logo 艺术字图片，无 Logo 时回退到文字标题
+  Widget _buildLogoOrTitle(TvHeroItem item) {
+    if (item.logoUrl != null && item.logoUrl!.isNotEmpty) {
+      return Image.network(
+        item.logoUrl!,
+        height: 48,
+        fit: BoxFit.contain,
+        alignment: Alignment.centerLeft,
+        errorBuilder: (_, __, ___) => _buildTitleText(item.title),
+        frameBuilder: (_, child, frame, wasSynchronouslyLoaded) {
+          if (wasSynchronouslyLoaded || frame != null) return child;
+          return _buildTitleText(item.title);
+        },
+      );
+    }
+    return _buildTitleText(item.title);
+  }
+
+  Widget _buildTitleText(String title) {
+    return Text(
+      title,
+      style: const TextStyle(
+        fontSize: TvDesignTokens.heroTitleSize,
+        color: TvDesignTokens.textPrimary,
+        fontWeight: FontWeight.bold,
+      ),
+    );
+  }
+
   Widget _buildPlaceholder() {
     return Container(
       color: TvDesignTokens.surfaceElevated,
@@ -300,6 +322,7 @@ class TvHeroItem {
   final List<String>? tags;
   final VoidCallback? onPlay;
   final VoidCallback? onDetail;
+  final String? logoUrl;      // Logo 艺术字图片 URL
 
   const TvHeroItem({
     this.imageUrl,
@@ -308,5 +331,6 @@ class TvHeroItem {
     this.tags,
     this.onPlay,
     this.onDetail,
+    this.logoUrl,
   });
 }

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -779,17 +779,7 @@ class _CarouselItem extends ConsumerWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               mainAxisSize: MainAxisSize.min,
               children: [
-                Text(
-                  item.name,
-                  style: const TextStyle(
-                    fontSize: 28,
-                    fontWeight: FontWeight.w800,
-                    color: Colors.white,
-                    shadows: [
-                      Shadow(blurRadius: 8, color: Colors.black54),
-                    ],
-                  ),
-                ),
+                _buildLogoOrTitle(item, api),
                 const SizedBox(height: 8),
                 Row(
                   children: [
@@ -830,9 +820,43 @@ class _CarouselItem extends ConsumerWidget {
       ),
     );
   }
-}
 
-/// 继续观看区块
+  /// 优先使用 Logo 艺术字图片，无 Logo 时回退到文字标题
+  Widget _buildLogoOrTitle(MediaItem item, dynamic api) {
+    final logoUrl = (item.logoItemId != null && item.logoImageTag != null)
+        ? api.image.getLogoImageUrl(item.logoItemId!, tag: item.logoImageTag, maxWidth: 280)
+        : null;
+
+    if (logoUrl != null && logoUrl.isNotEmpty) {
+      return Image.network(
+        logoUrl,
+        height: 48,
+        fit: BoxFit.contain,
+        alignment: Alignment.centerLeft,
+        errorBuilder: (_, __, ___) => _buildTitleText(item.name),
+        frameBuilder: (_, child, frame, wasSynchronouslyLoaded) {
+          if (wasSynchronouslyLoaded || frame != null) return child;
+          return _buildTitleText(item.name);
+        },
+      );
+    }
+    return _buildTitleText(item.name);
+  }
+
+  Widget _buildTitleText(String title) {
+    return Text(
+      title,
+      style: const TextStyle(
+        fontSize: 28,
+        fontWeight: FontWeight.w800,
+        color: Colors.white,
+        shadows: [
+          Shadow(blurRadius: 8, color: Colors.black54),
+        ],
+      ),
+    );
+  }
+}
 class ContinueWatchingSection extends ConsumerWidget {
   const ContinueWatchingSection({super.key});
   


### PR DESCRIPTION
## 功能说明

首页轮播图支持显示 Emby 服务器返回的艺术字 Logo 图片作为标题，无 Logo 时回退到纯文本标题。全平台（Mobile / Desktop / TV）均已实现。

## 改动内容

### API 层
- MediaItem 模型新增 logoItemId、logoImageTag 字段
- ImageApi 接口新增 getLogoImageUrl 方法
- EmbyImageApi 实现 getLogoImageUrl（imageType: Logo）
- _mediaFields / _libraryItemFields / _detailFields 请求 ParentLogoItemId,ParentLogoImageTag
- _parseMediaItem 解析 Logo 相关字段

### 工具层
- media_helpers.dart 新增 resolveMediaItemLogoUrl 函数，支持 Emby Logo 继承机制

### UI 层
- Mobile (home_screen.dart): 轮播图标题先显示文字，Logo 预加载成功后替换
- Desktop (desktop_home_screen.dart): 同上逻辑，Logo 高度 80px
- TV (tv_hero_banner.dart): TvHeroItem 新增 logoUrl 字段，同上逻辑

## 设计要点

- **文本优先**: 先渲染文字标题，Logo 通过 NetworkImage.resolve 预加载，加载成功后 setState 替换
- **原色显示**: 不做颜色映射，服务器返回什么显示什么
- **优雅降级**: Logo 加载失败时保持文字标题不变
- **无新依赖**: 仅使用 Flutter 内置组件和现有 API 客户端