### PR TITLE
fix: 修复 Surface 缓冲区初始化时机，解决 SurfaceSyncer 错误

### DIFF
--- a/android/app/src/main/kotlin/com/example/linplayer_mobile/MpvPlayerPlugin.kt
+++ b/android/app/src/main/kotlin/com/example/linplayer_mobile/MpvPlayerPlugin.kt
@@ -266,6 +266,14 @@ class MpvPlayerPlugin(
             // Always use SurfaceTexture for both gpu and gpu-next modes
             surfaceTextureEntry = textureRegistry.createSurfaceTexture()
             val surfaceTexture = surfaceTextureEntry.surfaceTexture()
+
+            // Set initial surface size using screen dimensions (landscape orientation)
+            // IMPORTANT: Must be set BEFORE creating Surface to avoid SurfaceSyncer errors
+            val dm = context.resources.displayMetrics
+            val screenW = if (dm.widthPixels > dm.heightPixels) dm.widthPixels else dm.heightPixels
+            val screenH = if (dm.widthPixels > dm.heightPixels) dm.heightPixels else dm.widthPixels
+            surfaceTexture.setDefaultBufferSize(screenW, screenH)
+
             val surface = Surface(surfaceTexture)
 
             // Create mpv context
@@ -278,12 +286,6 @@ class MpvPlayerPlugin(
             // Initialize mpv (registers JavaVM, starts event thread)
             MPVLib.init()
 
-            // Set initial surface size using screen dimensions (landscape orientation)
-            val dm = context.resources.displayMetrics
-            val screenW = if (dm.widthPixels > dm.heightPixels) dm.widthPixels else dm.heightPixels
-            val screenH = if (dm.widthPixels > dm.heightPixels) dm.heightPixels else dm.widthPixels
-
-            surfaceTextureEntry.surfaceTexture().setDefaultBufferSize(screenW, screenH)
             MPVLib.attachSurface(surface)
 
             // Notify mpv of initial render target dimensions


### PR DESCRIPTION
## 问题描述

在添加 Vulkan/libplacebo 支持后，应用出现 `SurfaceSyncer - Failed to find sync for id=X` 错误。

## 根本原因

`SurfaceTexture` 的 buffer 尺寸是在创建 `Surface` 对象**之后**才设置的。Vulkan 渲染器对 Surface 初始化时机更敏感，当它查询 buffer 尺寸时，尺寸还未设置，导致同步错误。

## 解决方案

将 `surfaceTexture.setDefaultBufferSize()` 调用移到 `Surface(surfaceTexture)` 之前，确保 buffer 在 Surface 创建时就已经配置好。

## 修改内容

**单一最小修改：** 调整了 `setDefaultBufferSize()` 的调用时机

```kotlin
// 之前：
val surface = Surface(surfaceTexture)
// ... 其他初始化 ...
surfaceTexture.setDefaultBufferSize(screenW, screenH)  // ❌ 太晚了

// 现在：
surfaceTexture.setDefaultBufferSize(screenW, screenH)  // ✅ 先设置
val surface = Surface(surfaceTexture)
// ... 其他初始化 ...
```

## 测试结果

✅ 视频正常播放（有画面有声音）
✅ gpu-next (Vulkan) 渲染正常工作
✅ 杜比视界支持正常
✅ 消除了 SurfaceSyncer 错误

## 相关 Issue

修复 #关联的issue号（如果有的话）