### PR TITLE
feat(mobile): 添加长按服务器按钮进入管理页功能并优化转场动画

### DIFF
--- a/lib/routes/app_router.dart
+++ b/lib/routes/app_router.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../core/providers/app_providers.dart';
+import '../core/providers/media_providers.dart';
 import '../core/theme/app_motion.dart';
 import '../plugins/plugin_system.dart';
 import '../ui/screens/detail/media_detail_screen.dart';
@@ -19,6 +20,8 @@ import '../ui/screens/server/icon_select_screen.dart';
 import '../ui/screens/server/server_lines_screen.dart';
 import '../ui/screens/server/server_list_screen.dart';
 import '../ui/screens/settings/settings_screen.dart';
+import '../ui/utils/media_helpers.dart';
+import '../ui/widgets/common/media_widgets.dart';
 
 final _rootNavigatorKey = GlobalKey<NavigatorState>();
 
@@ -519,16 +522,48 @@ class _FloatingTabBar extends StatelessWidget {
   }
 }
 
-class _ResumeRouteScreen extends StatelessWidget {
+class _ResumeRouteScreen extends ConsumerWidget {
   const _ResumeRouteScreen();
 
   @override
-  Widget build(BuildContext context) {
-    return const Scaffold(
-      body: SafeArea(
-        child: SingleChildScrollView(
-          padding: EdgeInsets.only(top: 8, bottom: 24),
-          child: ContinueWatchingSection(),
+  Widget build(BuildContext context, WidgetRef ref) {
+    final resumeAsync = ref.watch(resumeItemsProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('继续观看'),
+      ),
+      body: resumeAsync.when(
+        data: (items) {
+          if (items.isEmpty) {
+            return const Center(
+              child: Text('暂无继续观看的内容'),
+            );
+          }
+
+          return GridView.builder(
+            padding: const EdgeInsets.all(16),
+            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: 2,
+              childAspectRatio: 0.7,
+              crossAxisSpacing: 12,
+              mainAxisSpacing: 12,
+            ),
+            itemCount: items.length,
+            itemBuilder: (context, index) {
+              final item = items[index];
+              return MediaPoster(
+                item: item,
+                width: 150,
+                height: 200,
+                onTap: () => context.push(mediaRouteForItem(item)),
+              );
+            },
+          );
+        },
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (error, _) => Center(
+          child: Text('加载失败: $error'),
         ),
       ),
     );

--- a/lib/routes/app_router.dart
+++ b/lib/routes/app_router.dart
@@ -275,49 +275,62 @@ class _AnimatedBranchContainer extends StatefulWidget {
       _AnimatedBranchContainerState();
 }
 
-class _AnimatedBranchContainerState extends State<_AnimatedBranchContainer> {
+class _AnimatedBranchContainerState extends State<_AnimatedBranchContainer>
+    with SingleTickerProviderStateMixin {
+  late AnimationController _controller;
+  late Animation<Offset> _animation;
   int _previousIndex = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      duration: const Duration(milliseconds: 240),
+      vsync: this,
+    );
+    _animation = Tween<Offset>(
+      begin: Offset.zero,
+      end: Offset.zero,
+    ).animate(CurvedAnimation(
+      parent: _controller,
+      curve: Curves.easeOutCubic,
+    ));
+  }
 
   @override
   void didUpdateWidget(covariant _AnimatedBranchContainer oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.currentIndex != widget.currentIndex) {
+      final bool moveRight = widget.currentIndex > _previousIndex;
       _previousIndex = oldWidget.currentIndex;
+
+      // 设置动画方向
+      _animation = Tween<Offset>(
+        begin: Offset(moveRight ? 0.04 : -0.04, 0),
+        end: Offset.zero,
+      ).animate(CurvedAnimation(
+        parent: _controller,
+        curve: Curves.easeOutCubic,
+      ));
+
+      _controller.forward(from: 0.0);
     }
   }
 
   @override
-  Widget build(BuildContext context) {
-    final bool moveRight = widget.currentIndex > _previousIndex;
-    return Stack(
-      fit: StackFit.expand,
-      children: List<Widget>.generate(widget.children.length, (index) {
-        final bool isActive = index == widget.currentIndex;
-        final bool isLeaving = index == _previousIndex && !isActive;
-        // 收敛位移、去掉叠加的 AnimatedOpacity（每个分支一次 saveLayer），
-        // Tab 切换只做单层轻量滑动。
-        final double targetOffset = isActive
-            ? 0
-            : isLeaving
-                ? (moveRight ? -0.04 : 0.04)
-                : (index > widget.currentIndex ? 0.04 : -0.04);
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
 
-        return IgnorePointer(
-          ignoring: !isActive,
-          child: TickerMode(
-            enabled: isActive || isLeaving,
-            child: AnimatedSlide(
-              duration: const Duration(milliseconds: 240),
-              curve: Curves.easeOutCubic,
-              offset: Offset(targetOffset, 0),
-              child: Offstage(
-                offstage: !isActive && !isLeaving,
-                child: widget.children[index],
-              ),
-            ),
-          ),
-        );
-      }),
+  @override
+  Widget build(BuildContext context) {
+    return SlideTransition(
+      position: _animation,
+      child: IndexedStack(
+        index: widget.currentIndex,
+        children: widget.children,
+      ),
     );
   }
 }

--- a/lib/routes/app_router.dart
+++ b/lib/routes/app_router.dart
@@ -91,6 +91,7 @@ final appRouterProvider = Provider<GoRouter>((ref) {
                     pageBuilder: (context, state) => _buildHorizontalPage(
                       child: const AddServerScreen(),
                       state: state,
+                      direction: _PageTransitionDirection.forward,
                     ),
                   ),
                   GoRoute(
@@ -100,6 +101,7 @@ final appRouterProvider = Provider<GoRouter>((ref) {
                         serverId: state.pathParameters['serverId']!,
                       ),
                       state: state,
+                      direction: _PageTransitionDirection.forward,
                     ),
                   ),
                   GoRoute(
@@ -109,6 +111,7 @@ final appRouterProvider = Provider<GoRouter>((ref) {
                         serverId: state.pathParameters['serverId']!,
                       ),
                       state: state,
+                      direction: _PageTransitionDirection.forward,
                     ),
                   ),
                   GoRoute(
@@ -118,6 +121,7 @@ final appRouterProvider = Provider<GoRouter>((ref) {
                         serverId: state.pathParameters['serverId']!,
                       ),
                       state: state,
+                      direction: _PageTransitionDirection.forward,
                     ),
                   ),
                 ],

--- a/lib/routes/app_router.dart
+++ b/lib/routes/app_router.dart
@@ -20,6 +20,7 @@ import '../ui/screens/server/icon_select_screen.dart';
 import '../ui/screens/server/server_lines_screen.dart';
 import '../ui/screens/server/server_list_screen.dart';
 import '../ui/screens/settings/settings_screen.dart';
+import '../ui/utils/image_size_helper.dart';
 import '../ui/utils/media_helpers.dart';
 import '../ui/widgets/common/media_widgets.dart';
 
@@ -77,14 +78,6 @@ final appRouterProvider = Provider<GoRouter>((ref) {
                     path: 'home',
                     pageBuilder: (context, state) => _buildHorizontalPage(
                       child: const HomeScreen(),
-                      state: state,
-                      direction: _PageTransitionDirection.forward,
-                    ),
-                  ),
-                  GoRoute(
-                    path: 'resume',
-                    pageBuilder: (context, state) => _buildHorizontalPage(
-                      child: const _ResumeRouteScreen(),
                       state: state,
                       direction: _PageTransitionDirection.forward,
                     ),
@@ -164,6 +157,10 @@ final appRouterProvider = Provider<GoRouter>((ref) {
           state: state,
           direction: _PageTransitionDirection.forward,
         ),
+      ),
+      GoRoute(
+        path: '/resume',
+        builder: (context, state) => const _ResumeRouteScreen(),
       ),
       GoRoute(
         path: '/detail/:id',
@@ -541,22 +538,76 @@ class _ResumeRouteScreen extends ConsumerWidget {
             );
           }
 
+          final sizePreference = ImageSizeHelper.analyzeForResumeSection(items);
+
           return GridView.builder(
             padding: const EdgeInsets.all(16),
             gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
               crossAxisCount: 2,
-              childAspectRatio: 0.7,
+              childAspectRatio: 1.3,
               crossAxisSpacing: 12,
-              mainAxisSpacing: 12,
+              mainAxisSpacing: 16,
             ),
             itemCount: items.length,
             itemBuilder: (context, index) {
               final item = items[index];
-              return MediaPoster(
-                item: item,
-                width: 150,
-                height: 200,
+              final api = ref.read(apiClientProvider);
+              final imageUrls = resolveMediaItemImageUrls(
+                api,
+                item,
+                maxWidth: 400,
+                preferThumb: true,
+              );
+
+              return GestureDetector(
                 onTap: () => context.push(mediaRouteForItem(item)),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    // 封面图
+                    Expanded(
+                      child: ClipRRect(
+                        borderRadius: BorderRadius.circular(8),
+                        child: Stack(
+                          fit: StackFit.expand,
+                          children: [
+                            MediaImage(
+                              imageUrl: imageUrls.isNotEmpty ? imageUrls.first : null,
+                              imageUrls: imageUrls.length > 1 ? imageUrls.sublist(1) : null,
+                              width: 400,
+                              height: 225,
+                              fit: BoxFit.cover,
+                            ),
+                            // 进度条
+                            if (item.progress != null)
+                              Positioned(
+                                bottom: 0,
+                                left: 0,
+                                right: 0,
+                                child: LinearProgressIndicator(
+                                  value: item.progress,
+                                  backgroundColor: Colors.white.withValues(alpha: 0.3),
+                                  valueColor: const AlwaysStoppedAnimation(Color(0xFF5B8DEF)),
+                                  minHeight: 3,
+                                ),
+                              ),
+                          ],
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 6),
+                    // 标题
+                    SizedBox(
+                      height: 16,
+                      child: Text(
+                        item.name,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: const TextStyle(fontSize: 13),
+                      ),
+                    ),
+                  ],
+                ),
               );
             },
           );

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -958,7 +958,7 @@ class ContinueWatchingSection extends ConsumerWidget {
             HorizontalList(
               height: sizePreference.height + 50, // 高度 + 标题区域
               children: unplayedItems.asMap().entries.map((entry) {
-                return _ContinueWatchingCard(
+                return ContinueWatchingCard(
                   item: entry.value,
                   sizePreference: sizePreference,
                 ).appEntrance(index: entry.key);
@@ -978,11 +978,12 @@ class ContinueWatchingSection extends ConsumerWidget {
   }
 }
 
-class _ContinueWatchingCard extends ConsumerWidget {
+/// 公开的继续观看卡片，供其他页面使用
+class ContinueWatchingCard extends ConsumerWidget {
   final MediaItem item;
   final ImageSizePreference sizePreference;
 
-  const _ContinueWatchingCard({
+  const ContinueWatchingCard({
     required this.item,
     required this.sizePreference,
   });

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -984,6 +984,7 @@ class ContinueWatchingSection extends ConsumerWidget {
         showModalBottomSheet(
           context: context,
           isScrollControlled: true,
+          backgroundColor: Colors.transparent,
           builder: (context) => DraggableScrollableSheet(
             initialChildSize: 0.7,
             minChildSize: 0.3,

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../../../core/providers/app_providers.dart';
@@ -393,6 +394,11 @@ class _HomeAppBarState extends ConsumerState<_HomeAppBar> {
     _serverMenuOverlay = null;
   }
 
+  void _navigateToServerManagement() {
+    HapticFeedback.mediumImpact();
+    context.go('/');
+  }
+
   @override
   void deactivate() {
     _hideServerMenu();
@@ -420,6 +426,7 @@ class _HomeAppBarState extends ConsumerState<_HomeAppBar> {
               GestureDetector(
                 key: _serverButtonKey,
                 onTap: _showServerSelector,
+                onLongPress: _navigateToServerManagement,
                 child: Row(
                   mainAxisSize: MainAxisSize.min,
                   children: [

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -469,7 +469,7 @@ class _HomeAppBarState extends ConsumerState<_HomeAppBar> {
               IconButton(
                 icon: const Icon(Icons.collections_bookmark),
                 onPressed: () {
-                  context.go('/libraries');
+                  context.push('/libraries');
                 },
               ),
               // 搜索按钮
@@ -1341,7 +1341,7 @@ class LibrariesSection extends ConsumerWidget {
                     ),
                   ),
                   GestureDetector(
-                    onTap: () => context.go('/libraries'),
+                    onTap: () => context.push('/libraries'),
                     child: Row(
                       mainAxisSize: MainAxisSize.min,
                       children: [

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -990,49 +990,57 @@ class ContinueWatchingSection extends ConsumerWidget {
             maxChildSize: 0.9,
             expand: false,
             builder: (context, scrollController) {
-              return SafeArea(
-                child: Column(
-                  children: [
-                    Padding(
-                      padding: const EdgeInsets.all(16),
-                      child: Row(
-                        children: [
-                          const Text(
-                            '继续观看',
-                            style: TextStyle(
-                                fontSize: 18, fontWeight: FontWeight.w700),
-                          ),
-                          const Spacer(),
-                          IconButton(
-                            icon: const Icon(Icons.close),
-                            onPressed: () => Navigator.pop(context),
-                          ),
-                        ],
-                      ),
-                    ),
-                    const Divider(height: 1),
-                    Expanded(
-                      child: GridView.builder(
-                        controller: scrollController,
+              return Container(
+                decoration: BoxDecoration(
+                  color: Theme.of(context).scaffoldBackgroundColor,
+                  borderRadius: const BorderRadius.vertical(
+                    top: Radius.circular(16),
+                  ),
+                ),
+                child: SafeArea(
+                  child: Column(
+                    children: [
+                      Padding(
                         padding: const EdgeInsets.all(16),
-                        gridDelegate:
-                            const SliverGridDelegateWithFixedCrossAxisCount(
-                          crossAxisCount: 2,
-                          childAspectRatio: 1.5,
-                          crossAxisSpacing: 12,
-                          mainAxisSpacing: 12,
+                        child: Row(
+                          children: [
+                            const Text(
+                              '继续观看',
+                              style: TextStyle(
+                                  fontSize: 18, fontWeight: FontWeight.w700),
+                            ),
+                            const Spacer(),
+                            IconButton(
+                              icon: const Icon(Icons.close),
+                              onPressed: () => Navigator.pop(context),
+                            ),
+                          ],
                         ),
-                        itemCount: items.length,
-                        itemBuilder: (context, index) {
-                          final item = items[index];
-                          return _ContinueWatchingCard(
-                            item: item,
-                            sizePreference: sizePreference,
-                          );
-                        },
                       ),
-                    ),
-                  ],
+                      const Divider(height: 1),
+                      Expanded(
+                        child: GridView.builder(
+                          controller: scrollController,
+                          padding: const EdgeInsets.all(16),
+                          gridDelegate:
+                              const SliverGridDelegateWithFixedCrossAxisCount(
+                            crossAxisCount: 2,
+                            childAspectRatio: 1.5,
+                            crossAxisSpacing: 12,
+                            mainAxisSpacing: 12,
+                          ),
+                          itemCount: items.length,
+                          itemBuilder: (context, index) {
+                            final item = items[index];
+                            return _ContinueWatchingCard(
+                              item: item,
+                              sizePreference: sizePreference,
+                            );
+                          },
+                        ),
+                      ),
+                    ],
+                  ),
                 ),
               );
             },

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -973,84 +973,8 @@ class ContinueWatchingSection extends ConsumerWidget {
   }
 
   void _showContinueWatchingSheet(BuildContext context, WidgetRef ref) {
-    final resumeAsync = ref.read(resumeItemsProvider);
-    resumeAsync.when(
-      data: (items) {
-        if (items.isEmpty) return;
-
-        // 智能分析图片尺寸偏好
-        final sizePreference = ImageSizeHelper.analyzeForResumeSection(items);
-
-        showModalBottomSheet(
-          context: context,
-          isScrollControlled: true,
-          backgroundColor: Colors.transparent,
-          builder: (context) => DraggableScrollableSheet(
-            initialChildSize: 0.7,
-            minChildSize: 0.3,
-            maxChildSize: 0.9,
-            expand: false,
-            builder: (context, scrollController) {
-              return Container(
-                decoration: BoxDecoration(
-                  color: Theme.of(context).scaffoldBackgroundColor,
-                  borderRadius: const BorderRadius.vertical(
-                    top: Radius.circular(16),
-                  ),
-                ),
-                child: SafeArea(
-                  child: Column(
-                    children: [
-                      Padding(
-                        padding: const EdgeInsets.all(16),
-                        child: Row(
-                          children: [
-                            const Text(
-                              '继续观看',
-                              style: TextStyle(
-                                  fontSize: 18, fontWeight: FontWeight.w700),
-                            ),
-                            const Spacer(),
-                            IconButton(
-                              icon: const Icon(Icons.close),
-                              onPressed: () => Navigator.pop(context),
-                            ),
-                          ],
-                        ),
-                      ),
-                      const Divider(height: 1),
-                      Expanded(
-                        child: GridView.builder(
-                          controller: scrollController,
-                          padding: const EdgeInsets.all(16),
-                          gridDelegate:
-                              const SliverGridDelegateWithFixedCrossAxisCount(
-                            crossAxisCount: 2,
-                            childAspectRatio: 1.5,
-                            crossAxisSpacing: 12,
-                            mainAxisSpacing: 12,
-                          ),
-                          itemCount: items.length,
-                          itemBuilder: (context, index) {
-                            final item = items[index];
-                            return _ContinueWatchingCard(
-                              item: item,
-                              sizePreference: sizePreference,
-                            );
-                          },
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              );
-            },
-          ),
-        );
-      },
-      loading: () {},
-      error: (_, __) {},
-    );
+    // 直接导航到继续观看列表页，而不使用 ModalBottomSheet
+    context.push('/resume');
   }
 }
 

--- a/lib/ui/screens/server/add_server_screen.dart
+++ b/lib/ui/screens/server/add_server_screen.dart
@@ -441,7 +441,7 @@ class _AddServerScreenState extends ConsumerState<AddServerScreen> with SingleTi
       ref.read(authStateProvider.notifier).state = AuthState.authenticated;
 
       if (!mounted) return;
-      context.go('/home');
+      context.pushReplacement('/home');
     } catch (e) {
       setState(() { _errorMessage = _formatError(e); });
     } finally {
@@ -501,9 +501,9 @@ class _AddServerScreenState extends ConsumerState<AddServerScreen> with SingleTi
         ref.read(serverListProvider.notifier).addServer(server);
         ref.read(currentServerProvider.notifier).state = server;
         ref.read(authStateProvider.notifier).state = AuthState.authenticated;
-        
+
         if (!mounted) return;
-        context.go('/home');
+        context.pushReplacement('/home');
       } else {
         final server = ServerConfig(
           id: DateTime.now().millisecondsSinceEpoch.toString(),


### PR DESCRIPTION
## 功能说明

### 新增功能
- **长按服务器切换按钮进入服务器管理页**：用户可以通过长按首页左上角的服务器切换按钮，直接跳转到服务器管理页面，方便快速访问添加、编辑、删除服务器等功能
- **触觉反馈**：长按时提供触觉反馈，提升交互体验
- **继续观看全屏列表页**：将继续观看查看更多改为跳转到专门的全屏列表页，使用 2 列网格布局展示所有内容

### 动画优化
- **统一转场动画方向**：所有服务器管理相关页面（添加、编辑、线路管理、图标选择）使用统一的 forward 动画方向
- **改进页面跳转动画**：添加服务器成功后跳转到首页时，使用 `pushReplacement` 替代 `go`，触发流畅的页面转场动画

### Bug 修复
- **修复媒体库页面无法返回的问题**：将 `context.go('/libraries')` 改为 `context.push('/libraries')`，使用栈式导航确保返回按钮正常工作

## 技术实现

### 修改的文件
1. `lib/ui/screens/home/home_screen.dart`
   - 添加 `flutter/services.dart` 导入以支持触觉反馈
   - 新增 `_navigateToServerManagement()` 方法处理长按事件
   - 在 `GestureDetector` 上添加 `onLongPress` 回调
   - 修复媒体库导航方式（`go` → `push`）
   - 简化继续观看查看更多功能（使用 `context.push('/resume')`）
   - 将 `_ContinueWatchingCard` 改为公开组件 `ContinueWatchingCard`

2. `lib/routes/app_router.dart`
   - 为 `/add`、`/edit/:serverId`、`/lines/:serverId`、`/icons/:serverId` 路由添加 `direction: _PageTransitionDirection.forward`
   - 将 `/resume` 路由从 StatefulShellRoute 内移到外部，成为独立的全屏页面
   - 实现 `_ResumeRouteScreen` 使用 2 列网格布局
   - 每个卡片显示缩略图、进度条和单行标题
   - 添加必要的导入（`image_size_helper`、`media_helpers`、`media_widgets`）

3. `lib/ui/screens/server/add_server_screen.dart`
   - 将添加服务器成功后的 `context.go('/home')` 改为 `context.pushReplacement('/home')`

## 用户体验改进

### 交互流程
- **短按**服务器按钮：打开服务器切换下拉菜单（保持原有功能）
- **长按**服务器按钮：触觉反馈 + 平滑动画跳转到服务器管理页
- **媒体库返回**：点击返回按钮可正常返回首页
- **继续观看查看更多**：跳转到全屏的 2 列网格列表页，顶部有标题栏和返回按钮，无底部 Tab 栏干扰

### 动画效果
- 使用项目现有的 `AppMotion` 动效系统
- 转场时长：240ms (forward) / 200ms (reverse)
- 曲线：`Curves.easeOutCubic` (进入) / `Curves.easeInCubic` (返回)
- 效果：水平滑动 + 淡入淡出组合

## 测试

- ✅ Flutter 静态分析通过
- ✅ 长按功能正常工作
- ✅ 转场动画流畅自然
- ✅ 媒体库返回功能正常
- ✅ 继续观看全屏列表正常显示，布局整齐
- ✅ 不影响现有功能

## Commits
- `9c84dd3` fix: 优化移动端底部 Tab 切换动画
- `7f7849c` feat(mobile): 添加长按服务器按钮进入管理页功能并优化页面转场动画
- `43da28a` fix: 修复媒体库页面无法返回的问题
- `63beebd` fix: 设置弹窗背景透明以显示内容容器
- `7515740` fix: 修复继续观看查看更多功能
- `55388ff` feat: 添加继续观看全屏列表页

## 相关 Issue

解决了移动端页面转场动画生硬的问题，并修复了多个影响用户体验的 bug，新增了继续观看全屏列表页，提升了整体交互体验。