### PR TITLE
安全加固第二批 (H9/M5/L5/L1/M1/L2/L8/L9/M6)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -642,6 +642,27 @@ jobs:
           }
           Write-Host "libmpv-2.dll 完整版就绪，大小: $($targetInfo.Length) bytes"
 
+      - name: Bundle ffmpeg (内置，避免运行时无校验下载，M6)
+        shell: pwsh
+        run: |
+          $outputDir = "build/windows/x64/runner/Release"
+          try {
+            $tmp = Join-Path $env:RUNNER_TEMP "ffmpeg-win"
+            New-Item -ItemType Directory -Force -Path $tmp | Out-Null
+            $zip = Join-Path $tmp "ffmpeg.zip"
+            Invoke-WebRequest -UseBasicParsing -Uri "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-gpl.zip" -OutFile $zip
+            Expand-Archive -Path $zip -DestinationPath $tmp -Force
+            $exe = Get-ChildItem -Path $tmp -Recurse -Filter "ffmpeg.exe" | Select-Object -First 1
+            if ($exe) {
+              Copy-Item $exe.FullName (Join-Path $outputDir "ffmpeg.exe") -Force
+              Write-Host "Bundled ffmpeg.exe ($($exe.Length) bytes)"
+            } else {
+              Write-Host "::warning::ffmpeg.exe 未在归档中找到，跳过内置"
+            }
+          } catch {
+            Write-Host "::warning::内置 ffmpeg 失败（不阻断构建）: $_"
+          }
+
       - name: Package Windows Build
         shell: pwsh
         run: |
@@ -715,6 +736,18 @@ jobs:
             --dart-define=DANDANPLAY_APP_ID="$CLEAN_ID" \
             --dart-define=DANDANPLAY_APP_SECRET="$CLEAN_SECRET"
 
+      - name: Bundle ffmpeg (内置，避免运行时无校验下载，M6)
+        run: |
+          OUT="build/linux/x64/release/bundle"
+          set +e
+          curl -fsSL -o /tmp/ffmpeg.tar.xz "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl.tar.xz" \
+            && mkdir -p /tmp/ffmpeg && tar -xf /tmp/ffmpeg.tar.xz -C /tmp/ffmpeg \
+            && FF=$(find /tmp/ffmpeg -type f -name ffmpeg | head -n1) \
+            && cp "$FF" "$OUT/ffmpeg" && chmod +x "$OUT/ffmpeg" \
+            && echo "Bundled ffmpeg: $(ls -la "$OUT/ffmpeg")"
+          if [ ! -f "$OUT/ffmpeg" ]; then echo "::warning::内置 ffmpeg 失败（不阻断构建）"; fi
+          set -e
+
       - name: Package Linux Build
         run: |
           VERSION="${{ needs.prepare.outputs.version }}"
@@ -781,6 +814,19 @@ jobs:
             --dart-define=APP_VERSION="${{ needs.prepare.outputs.version }}" \
             --dart-define=DANDANPLAY_APP_ID="$CLEAN_ID" \
             --dart-define=DANDANPLAY_APP_SECRET="$CLEAN_SECRET"
+
+      - name: Bundle ffmpeg (内置，避免运行时无校验下载，M6)
+        run: |
+          APP_PATH=$(find build/macos/Build/Products/Release -maxdepth 1 -type d -name "*.app" | head -n 1)
+          MACOS_DIR="$APP_PATH/Contents/MacOS"
+          set +e
+          curl -fsSL -o /tmp/ffmpeg.zip "https://evermeet.cx/ffmpeg/getrelease/ffmpeg/zip" \
+            && mkdir -p /tmp/ffmpeg && unzip -o /tmp/ffmpeg.zip -d /tmp/ffmpeg \
+            && FF=$(find /tmp/ffmpeg -type f -name ffmpeg | head -n1) \
+            && cp "$FF" "$MACOS_DIR/ffmpeg" && chmod +x "$MACOS_DIR/ffmpeg" \
+            && echo "Bundled ffmpeg into app bundle: $(ls -la "$MACOS_DIR/ffmpeg")"
+          if [ ! -f "$MACOS_DIR/ffmpeg" ]; then echo "::warning::内置 ffmpeg 失败（不阻断构建）"; fi
+          set -e
 
       - name: Package macOS Build
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -714,8 +714,9 @@ jobs:
       - name: Install Linux desktop dependencies
         run: |
           sudo apt-get update
-          # media_kit_video links libmpv via pkg-config on Linux.
-          sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev libmpv-dev libepoxy-dev
+          # media_kit_video links libmpv via pkg-config on Linux；
+          # flutter_secure_storage_linux 需要 libsecret-1 + jsoncpp（H11 凭据加密）。
+          sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev libmpv-dev libepoxy-dev libsecret-1-dev libjsoncpp-dev
 
       - name: Enable Linux desktop
         run: flutter config --enable-linux-desktop

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,12 @@ migrate_working_dir/
 .agents/
 skills-lock.json
 
+# Claude Code 本地文件（技能 SKILL.md、本地设置、worktree 等仅本地，不提交）
+.claude/skills/
+.claude/settings.local.json
+.claude/worktrees/
+.claude/plans/
+
 # Zed Editor
 .zed/
 

--- a/lib/core/providers/translation_providers.dart
+++ b/lib/core/providers/translation_providers.dart
@@ -9,6 +9,7 @@ import '../services/translation/subtitle_document.dart';
 import '../services/translation/subtitle_translation_service.dart';
 import '../services/translation/translation_engine.dart';
 import '../services/translation/whisper/whisper_model.dart';
+import '../services/secure_credential_store.dart';
 import 'app_preferences.dart';
 
 // ============ 引擎选择与目标语言 ============
@@ -58,11 +59,12 @@ final bilingualLayoutProvider =
 
 // ============ 各引擎配置 ============
 
+// 翻译引擎配置含 apiKey/secretKey，改存 OS 安全加密 KV（M5），不再明文进 prefs。
 PreferenceNotifier<AiEngineConfig> _aiNotifier(String key, AiEngineConfig def) {
   return PreferenceNotifier<AiEngineConfig>(
     defaultValue: def,
-    readValue: (prefs) {
-      final s = prefs.getString(key);
+    readValue: (_) {
+      final s = SecureCredentialStore.instance.readKv(key);
       if (s == null) return null;
       try {
         return AiEngineConfig.fromJson(jsonDecode(s) as Map<String, dynamic>);
@@ -70,8 +72,9 @@ PreferenceNotifier<AiEngineConfig> _aiNotifier(String key, AiEngineConfig def) {
         return null;
       }
     },
-    writeValue: (prefs, value) async {
-      await prefs.setString(key, jsonEncode(value.toJson()));
+    writeValue: (_, value) async {
+      await SecureCredentialStore.instance
+          .writeKv(key, jsonEncode(value.toJson()));
     },
   );
 }
@@ -88,8 +91,8 @@ final anthropicConfigProvider =
 PreferenceNotifier<BaiduEngineConfig> _baiduNotifier(String key) {
   return PreferenceNotifier<BaiduEngineConfig>(
     defaultValue: const BaiduEngineConfig(),
-    readValue: (prefs) {
-      final s = prefs.getString(key);
+    readValue: (_) {
+      final s = SecureCredentialStore.instance.readKv(key);
       if (s == null) return null;
       try {
         return BaiduEngineConfig.fromJson(jsonDecode(s) as Map<String, dynamic>);
@@ -97,8 +100,9 @@ PreferenceNotifier<BaiduEngineConfig> _baiduNotifier(String key) {
         return null;
       }
     },
-    writeValue: (prefs, value) async {
-      await prefs.setString(key, jsonEncode(value.toJson()));
+    writeValue: (_, value) async {
+      await SecureCredentialStore.instance
+          .writeKv(key, jsonEncode(value.toJson()));
     },
   );
 }
@@ -117,8 +121,8 @@ final tencentConfigProvider = StateNotifierProvider<
     PreferenceNotifier<TencentEngineConfig>, TencentEngineConfig>((ref) {
   return PreferenceNotifier<TencentEngineConfig>(
     defaultValue: const TencentEngineConfig(),
-    readValue: (prefs) {
-      final s = prefs.getString('linplayer_trans_tencent');
+    readValue: (_) {
+      final s = SecureCredentialStore.instance.readKv('linplayer_trans_tencent');
       if (s == null) return null;
       try {
         return TencentEngineConfig.fromJson(
@@ -127,8 +131,9 @@ final tencentConfigProvider = StateNotifierProvider<
         return null;
       }
     },
-    writeValue: (prefs, value) async {
-      await prefs.setString('linplayer_trans_tencent', jsonEncode(value.toJson()));
+    writeValue: (_, value) async {
+      await SecureCredentialStore.instance
+          .writeKv('linplayer_trans_tencent', jsonEncode(value.toJson()));
     },
   );
 });

--- a/lib/core/services/deep_link_service.dart
+++ b/lib/core/services/deep_link_service.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:app_links/app_links.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../desktop/routes/desktop_router.dart';
@@ -73,6 +74,19 @@ class DeepLinkService {
       return;
     }
 
+    // H9/M8/M4/L6：外部链接完全不可信，必须经用户显式确认（展示 host/用户名/
+    // 弹幕源数量、明文 HTTP 警告）后，才登录、添加、设为当前并入弹幕源。
+    final confirmed = await _confirmAddServer(
+      name: name,
+      username: user,
+      lineUrls: block.lines.map((l) => l.url).toList(),
+      danmakuCount: block.danmakuLines.length,
+    );
+    if (!confirmed) {
+      _logger.i('DeepLink', '用户取消（或无 UI 上下文）未添加深链服务器');
+      return;
+    }
+
     try {
       final server = await ServerBatchAdder.authenticateBlock(
         block,
@@ -124,6 +138,81 @@ class DeepLinkService {
           if (u.trim().isNotEmpty) ParsedLine('弹幕', u.trim()),
       ],
     );
+  }
+
+  /// 取当前平台路由器的根导航器 context（用于弹确认框）。拿不到返回 null。
+  BuildContext? _navContext() {
+    try {
+      if (isTvPlatform) {
+        return tvRouter.routerDelegate.navigatorKey.currentContext;
+      }
+      if (isDesktopPlatform) {
+        return container
+            .read(desktopRouterProvider)
+            .routerDelegate
+            .navigatorKey
+            .currentContext;
+      }
+      return container
+          .read(appRouterProvider)
+          .routerDelegate
+          .navigatorKey
+          .currentContext;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// 弹出确认框：用户同意才返回 true。无 UI 上下文（拿不到导航器）一律返回
+  /// false——安全默认：不确认就不自动添加，杜绝网页/二维码 drive-by。
+  Future<bool> _confirmAddServer({
+    String? name,
+    required String username,
+    required List<String> lineUrls,
+    required int danmakuCount,
+  }) async {
+    final context = _navContext();
+    if (context == null || !context.mounted) {
+      _logger.w('DeepLink', '无可用 UI 上下文，拒绝自动添加服务器');
+      return false;
+    }
+    final hosts = lineUrls.map(_hostOf).toSet().join('、');
+    final hasHttp = lineUrls.any((u) => ServerBatchAdder.normalizeUrl(u)
+        .toLowerCase()
+        .startsWith('http://'));
+    final result = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('通过链接添加服务器？'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text('有外部链接请求添加并登录以下服务器，确认前请核实来源可信：',
+                style: TextStyle(fontSize: 13)),
+            const SizedBox(height: 12),
+            if (name != null && name.trim().isNotEmpty) Text('名称：$name'),
+            Text('主机：${hosts.isEmpty ? '（未知）' : hosts}'),
+            Text('用户名：$username'),
+            if (danmakuCount > 0) Text('附带弹幕源：$danmakuCount 条'),
+            if (hasHttp) ...[
+              const SizedBox(height: 8),
+              const Text('⚠ 含明文 HTTP 线路，账号密码将以明文传输',
+                  style: TextStyle(color: Colors.orange, fontSize: 12)),
+            ],
+          ],
+        ),
+        actions: [
+          TextButton(
+              onPressed: () => Navigator.pop(ctx, false),
+              child: const Text('取消')),
+          FilledButton(
+              onPressed: () => Navigator.pop(ctx, true),
+              child: const Text('添加并登录')),
+        ],
+      ),
+    );
+    return result ?? false;
   }
 
   void _goHome() {

--- a/lib/core/services/secure_credential_store.dart
+++ b/lib/core/services/secure_credential_store.dart
@@ -32,20 +32,65 @@ class SecureCredentialStore {
   static final AppLogger _log = AppLogger();
 
   static const _securePrefix = 'srv_secret_';
+  static const _kvPrefix = 'kv_secret_';
   static const _serversPrefsKey = 'linplayer_servers';
   static const _fallbackPrefsKey = 'linplayer_server_secrets_fb';
+  static const _kvFallbackPrefsKey = 'linplayer_kv_secrets_fb';
   static const _fbPassphrase = 'LinPlayer::server::cred::fallback::v1';
+
+  /// 启动时把这些旧明文 prefs 字符串键迁移进加密 KV（如翻译引擎 API key，M5）。
+  static const _legacyKvKeys = <String>[
+    'linplayer_trans_openai',
+    'linplayer_trans_anthropic',
+    'linplayer_trans_baidu_general',
+    'linplayer_trans_baidu_llm',
+    'linplayer_trans_tencent',
+  ];
 
   final _storage = const FlutterSecureStorage(
     aOptions: AndroidOptions(encryptedSharedPreferences: true),
   );
   final Map<String, ServerSecret> _cache = {};
+  final Map<String, String> _kv = {};
   bool _useFallback = false;
   bool _initialized = false;
   List<int>? _fbKeyCache;
 
-  /// 同步读取（启动后缓存已就绪）。
+  /// 同步读取服务器凭据（启动后缓存已就绪）。
   ServerSecret? read(String id) => _cache[id];
+
+  /// 同步读取通用加密 KV（启动后缓存已就绪）。
+  String? readKv(String key) => _kv[key];
+
+  Future<void> writeKv(String key, String? value) async {
+    if (value == null || value.isEmpty) {
+      await removeKv(key);
+      return;
+    }
+    _kv[key] = value;
+    if (_useFallback) {
+      await _persistKvFallback();
+      return;
+    }
+    try {
+      await _storage.write(key: '$_kvPrefix$key', value: value);
+    } catch (e) {
+      _useFallback = true;
+      _log.w('SecureCred', '写安全存储(KV)失败，回退混淆: $e');
+      await _persistKvFallback();
+    }
+  }
+
+  Future<void> removeKv(String key) async {
+    _kv.remove(key);
+    if (_useFallback) {
+      await _persistKvFallback();
+      return;
+    }
+    try {
+      await _storage.delete(key: '$_kvPrefix$key');
+    } catch (_) {}
+  }
 
   Future<void> initialize() async {
     if (_initialized) return;
@@ -56,15 +101,32 @@ class SecureCredentialStore {
       for (final e in all.entries) {
         if (e.key.startsWith(_securePrefix)) {
           _cache[e.key.substring(_securePrefix.length)] = _decode(e.value);
+        } else if (e.key.startsWith(_kvPrefix)) {
+          _kv[e.key.substring(_kvPrefix.length)] = e.value;
         }
       }
     } catch (e) {
       _useFallback = true;
       _log.w('SecureCred', 'OS 安全存储不可用，回退混淆存储: $e');
       _loadFallbackCache();
+      _loadKvFallbackCache();
     }
-    // 2) 迁移旧版本明文落盘的 password/authToken。
+    // 2) 迁移旧版本明文落盘的 password/authToken 与通用 KV（翻译 API key 等）。
     await _migrateLegacyPlaintext();
+    await _migrateLegacyKv();
+  }
+
+  /// 把旧明文 prefs 字符串键搬进加密 KV，并从 prefs 抹除明文。
+  Future<void> _migrateLegacyKv() async {
+    final prefs = AppPreferencesStore.instance;
+    for (final key in _legacyKvKeys) {
+      final raw = prefs.getString(key);
+      if (raw == null || raw.isEmpty) continue;
+      if (!_kv.containsKey(key)) {
+        await writeKv(key, raw);
+      }
+      await prefs.remove(key);
+    }
   }
 
   Future<void> write(String id,
@@ -195,6 +257,28 @@ class SecureCredentialStore {
           .setString(_fallbackPrefsKey, _xor(jsonEncode(m)));
     } catch (e) {
       _log.w('SecureCred', '回退存储写入失败: $e');
+    }
+  }
+
+  void _loadKvFallbackCache() {
+    try {
+      final raw = AppPreferencesStore.instance.getString(_kvFallbackPrefsKey);
+      if (raw == null || raw.isEmpty) return;
+      final plain = _unxor(raw);
+      if (plain == null) return;
+      final m = jsonDecode(plain) as Map<String, dynamic>;
+      for (final e in m.entries) {
+        _kv[e.key] = '${e.value}';
+      }
+    } catch (_) {}
+  }
+
+  Future<void> _persistKvFallback() async {
+    try {
+      await AppPreferencesStore.instance
+          .setString(_kvFallbackPrefsKey, _xor(jsonEncode(_kv)));
+    } catch (e) {
+      _log.w('SecureCred', '回退存储(KV)写入失败: $e');
     }
   }
 }

--- a/lib/core/services/sync/sync_secure_store.dart
+++ b/lib/core/services/sync/sync_secure_store.dart
@@ -2,38 +2,29 @@ import 'dart:convert';
 import 'package:crypto/crypto.dart';
 
 import '../../providers/app_preferences.dart';
+import '../secure_credential_store.dart';
 import 'sync_models.dart';
 
-/// 同步账号令牌的持久化。
+/// 同步账号令牌的持久化（L5：改用 OS 安全存储真加密）。
 ///
-/// 沿用 App 现有的 SharedPreferences 存储，但令牌不以明文落盘：
-/// JSON 先 XOR 混淆（keystream = SHA256(passphrase) 循环）再 base64。
-/// 与 [ObfuscatedSecrets] 一样，这是「防 grep/strings」级别的混淆，
-/// 不是强加密；真正高安全场景应使用系统钥匙串或后端代理。
+/// Trakt/Bangumi 的 access/refresh token 改存 [SecureCredentialStore] 的加密 KV
+/// （OS 钥匙串）。旧版本曾用「静态密钥 XOR 混淆 + base64」写在 SharedPreferences
+/// （可逆，仅防 grep），这里在**读取时惰性迁移**：解混淆后写入加密 KV 并抹除旧值。
 class SyncSecureStore {
   SyncSecureStore._();
 
-  static const String _passphrase = 'LinPlayer::sync::token::v1';
+  // 仅用于迁移旧 XOR 混淆值的口令/密钥（新写入不再使用 XOR）。
+  static const String _legacyPassphrase = 'LinPlayer::sync::token::v1';
   static const String _keyPrefix = 'sync_account_';
-  static List<int>? _keyCache;
+  static List<int>? _legacyKeyCache;
 
-  static List<int> get _key =>
-      _keyCache ??= sha256.convert(utf8.encode(_passphrase)).bytes;
-
-  static String _obfuscate(String plain) {
-    final bytes = utf8.encode(plain);
-    final key = _key;
-    final out = List<int>.filled(bytes.length, 0);
-    for (var i = 0; i < bytes.length; i++) {
-      out[i] = bytes[i] ^ key[i % key.length];
-    }
-    return base64Encode(out);
-  }
+  static List<int> get _legacyKey =>
+      _legacyKeyCache ??= sha256.convert(utf8.encode(_legacyPassphrase)).bytes;
 
   static String? _deobfuscate(String encoded) {
     try {
       final bytes = base64Decode(encoded);
-      final key = _key;
+      final key = _legacyKey;
       final out = List<int>.filled(bytes.length, 0);
       for (var i = 0; i < bytes.length; i++) {
         out[i] = bytes[i] ^ key[i % key.length];
@@ -47,21 +38,30 @@ class SyncSecureStore {
   static String _prefKey(SyncService service) => '$_keyPrefix${service.id}';
 
   static SyncAccount? read(SyncService service) {
-    final raw = AppPreferencesStore.instance.getString(_prefKey(service));
-    if (raw == null || raw.isEmpty) return null;
-    final plain = _deobfuscate(raw);
+    final key = _prefKey(service);
+    // 新：加密 KV（同步缓存）。
+    final kv = SecureCredentialStore.instance.readKv(key);
+    if (kv != null) return SyncAccount.decode(kv);
+    // 旧：XOR 混淆值 → 惰性迁移到加密 KV。
+    final legacy = AppPreferencesStore.instance.getString(key);
+    if (legacy == null || legacy.isEmpty) return null;
+    final plain = _deobfuscate(legacy);
     if (plain == null) return null;
+    // 异步迁移，不阻塞本次读取。
+    SecureCredentialStore.instance.writeKv(key, plain);
+    AppPreferencesStore.instance.remove(key);
     return SyncAccount.decode(plain);
   }
 
   static Future<void> write(SyncAccount account) async {
-    await AppPreferencesStore.instance.setString(
-      _prefKey(account.service),
-      _obfuscate(account.encode()),
-    );
+    await SecureCredentialStore.instance
+        .writeKv(_prefKey(account.service), account.encode());
   }
 
   static Future<void> clear(SyncService service) async {
-    await AppPreferencesStore.instance.remove(_prefKey(service));
+    final key = _prefKey(service);
+    await SecureCredentialStore.instance.removeKv(key);
+    // 清理可能残留的旧混淆值。
+    await AppPreferencesStore.instance.remove(key);
   }
 }

--- a/lib/plugins/manager/plugin_manager.dart
+++ b/lib/plugins/manager/plugin_manager.dart
@@ -26,6 +26,8 @@ import 'plugin_installer.dart';
 class PluginManager extends ChangeNotifier {
   static final AppLogger _log = AppLogger();
   static const _enabledKey = 'linplayer_enabled_plugins';
+  /// 同时启用插件数的全局上限（每插件独立 isolate ~64MB，限数量即限总内存）。
+  static const int maxEnabledPlugins = 16;
   // 每个插件“用户已同意的权限集”，用于检测更新提权（新清单申请了未同意的权限）。
   static const _approvedPermsKey = 'linplayer_plugin_approved_perms';
 
@@ -218,10 +220,18 @@ class PluginManager extends ChangeNotifier {
 
     // 激活已启用的插件；若清单权限超出已同意范围（疑似更新提权），强制禁用待重新授权。
     var forcedDisable = false;
+    var activated = 0;
     for (final info in _plugins.values) {
       if (!_enabledIds.contains(info.id)) continue;
       if (_permissionsApproved(info)) {
+        if (activated >= maxEnabledPlugins) {
+          info.status = PluginStatus.disabled;
+          info.error = '超出同时启用插件数上限（$maxEnabledPlugins），未激活';
+          _log.w('PluginManager', '插件 ${info.id} 超出并发上限，跳过激活');
+          continue;
+        }
         await _activate(info);
+        activated++;
       } else {
         _enabledIds.remove(info.id);
         forcedDisable = true;
@@ -256,6 +266,9 @@ class PluginManager extends ChangeNotifier {
   Future<void> enable(String id) async {
     final info = _plugins[id];
     if (info == null) throw StateError('插件不存在: $id');
+    if (!_enabledIds.contains(id) && _enabledIds.length >= maxEnabledPlugins) {
+      throw StateError('已达到同时启用插件数上限（$maxEnabledPlugins 个），请先禁用其它插件');
+    }
     _enabledIds.add(id);
     _approvedPerms[id] = info.manifest.permissions.toSet();
     await _persistEnabledIds();

--- a/lib/plugins/runtime/plugin_context_bridge.dart
+++ b/lib/plugins/runtime/plugin_context_bridge.dart
@@ -155,6 +155,13 @@ class PluginContextBridge {
       throw Exception('不支持的 http 方法: $method');
     }
 
+    // 防重定向绕白名单（L1）：白名单主机若 302 跳到名单外/内网，最终 URL 的
+    // host 必须仍在白名单，否则拒绝把重定向内容回传给插件。
+    final finalHost = response.realUri.host;
+    if (!httpAllowedHosts.contains(finalHost)) {
+      throw Exception('请求经重定向到了白名单外主机: $finalHost');
+    }
+
     return {
       'status': response.statusCode,
       'headers': response.headers.map,
@@ -307,6 +314,13 @@ class PluginContextBridge {
         _require(PluginPermissions.embyCredentials.id);
         final s = container.read(currentServerProvider);
         if (s == null) return null;
+        // M1：逐次确认 + 明文密码警告，用户拒绝则视为本次未授权。
+        final approved =
+            await PluginUiHost.confirmCredentialAccess(manifest.name);
+        if (!approved) {
+          throw PluginPermissionError(
+              pluginId, PluginPermissions.embyCredentials.id);
+        }
         return {
           'username': s.username,
           'password': s.password,

--- a/lib/plugins/runtime/plugin_runtime.dart
+++ b/lib/plugins/runtime/plugin_runtime.dart
@@ -13,9 +13,11 @@ import 'plugin_player_bridge.dart';
 /// 单个插件的运行时：持有独立的 JS 引擎 + ctx 桥，负责加载、事件转发、回调触发。
 ///
 /// 安全约束：
-///  - 每次进入 JS 的调用都有 [callTimeout]（默认 1s）超时；
+///  - 每次进入 JS 的调用都有 [callTimeout]（30s 墙钟）超时；
 ///  - 超时被视为插件失控 —— 销毁引擎并回调 [onFault] 让管理器禁用插件；
-///  - 任何 JS 异常都被捕获，不会冒泡到主程序。
+///  - 任何 JS 异常都被捕获，不会冒泡到主程序；
+///  - 同时启用的插件数由 `PluginManager.maxEnabledPlugins` 全局封顶，间接约束
+///    总内存（每插件独立 isolate，堆上限约 64MB）。
 class PluginRuntime {
   static final AppLogger _log = AppLogger();
 

--- a/lib/plugins/runtime/plugin_ui_host.dart
+++ b/lib/plugins/runtime/plugin_ui_host.dart
@@ -36,6 +36,36 @@ class PluginUiHost {
     ));
   }
 
+  /// 凭据访问逐次确认（M1）：插件每次调用 getCredentials 都弹此框，明确警告
+  /// 密码将明文交给插件。用户点「允许本次」才返回 true；无 UI 上下文一律拒绝。
+  static Future<bool> confirmCredentialAccess(String pluginName) async {
+    final ctx = _context;
+    if (ctx == null) {
+      _log.w('PluginUI', '无UI上下文，拒绝插件读取凭据');
+      return false;
+    }
+    final result = await showDialogGeneric<bool>(
+      ctx,
+      (context) => AlertDialog(
+        title: const Text('允许插件读取账号密码？'),
+        content: Text(
+          '插件「$pluginName」请求读取你当前服务器的用户名与密码。\n\n'
+          '⚠ 密码将以明文交给该插件，可能被用于登录其它网站或外发到网络。'
+          '仅在你完全信任该插件时允许。',
+        ),
+        actions: [
+          TextButton(
+              onPressed: () => Navigator.of(context).pop(false),
+              child: const Text('拒绝')),
+          FilledButton(
+              onPressed: () => Navigator.of(context).pop(true),
+              child: const Text('允许本次')),
+        ],
+      ),
+    );
+    return result ?? false;
+  }
+
   /// 弹出对话框，返回被点击按钮的 id（或 null）。
   static Future<String?> showAlert(Map options) async {
     final ctx = _context;

--- a/windows/runner/main.cpp
+++ b/windows/runner/main.cpp
@@ -9,6 +9,64 @@
 #include "flutter_window.h"
 #include "utils.h"
 
+namespace {
+
+// 取某进程的可执行映像完整路径（用于校验目标窗口的归属进程）。
+std::wstring ProcessImagePath(DWORD pid) {
+  std::wstring path;
+  HANDLE h = ::OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
+  if (h != nullptr) {
+    wchar_t buf[MAX_PATH];
+    DWORD len = MAX_PATH;
+    if (::QueryFullProcessImageNameW(h, 0, buf, &len)) {
+      path.assign(buf, len);
+    }
+    ::CloseHandle(h);
+  }
+  return path;
+}
+
+std::wstring SelfImagePath() {
+  wchar_t buf[MAX_PATH];
+  DWORD len = ::GetModuleFileNameW(nullptr, buf, MAX_PATH);
+  return std::wstring(buf, len);
+}
+
+struct EnumCtx {
+  std::wstring exe_path;
+  DWORD self_pid;
+  HWND found;
+};
+
+BOOL CALLBACK EnumProc(HWND hwnd, LPARAM lparam) {
+  auto *ctx = reinterpret_cast<EnumCtx *>(lparam);
+  wchar_t cls[256] = {0};
+  if (::GetClassNameW(hwnd, cls, 256) == 0) return TRUE;
+  if (std::wstring(cls) != L"FLUTTER_RUNNER_WIN32_WINDOW") return TRUE;
+  wchar_t title[256] = {0};
+  ::GetWindowTextW(hwnd, title, 256);
+  if (std::wstring(title) != L"Linplayer") return TRUE;
+  DWORD pid = 0;
+  ::GetWindowThreadProcessId(hwnd, &pid);
+  if (pid == 0 || pid == ctx->self_pid) return TRUE;
+  // L8：必须确认该窗口归属的进程确实是同一个 LinPlayer.exe，否则可能是本地
+  // 恶意进程伪造同类同标题窗口企图拦截被转发的(可能含凭据的)深链。
+  if (_wcsicmp(ProcessImagePath(pid).c_str(), ctx->exe_path.c_str()) == 0) {
+    ctx->found = hwnd;
+    return FALSE;  // 命中，停止枚举
+  }
+  return TRUE;
+}
+
+// 找到「另一个运行中的本程序实例」的主窗口；找不到/只有伪造窗口则返回 nullptr。
+HWND FindOurInstanceWindow() {
+  EnumCtx ctx{SelfImagePath(), ::GetCurrentProcessId(), nullptr};
+  ::EnumWindows(EnumProc, reinterpret_cast<LPARAM>(&ctx));
+  return ctx.found;
+}
+
+}  // namespace
+
 int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
                       _In_ wchar_t *command_line, _In_ int show_command) {
   // 自定义协议深链(linplayer://...)单实例转发：
@@ -29,8 +87,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
       ::LocalFree(argv);
     }
     if (has_link) {
-      HWND existing =
-          ::FindWindow(L"FLUTTER_RUNNER_WIN32_WINDOW", L"Linplayer");
+      HWND existing = FindOurInstanceWindow();
       if (existing != nullptr) {
         // 把运行中的窗口带到前台，再转发链接，体验上即「唤起」。
         if (::IsIconic(existing)) {


### PR DESCRIPTION
## 概要
安全审计第二批修复（接续已合入的 H1–H13 / H2·M7 / H6 批 / H10–H12）。

- **H9/M8/M4/L6** deeplink `add-server` 加用户确认对话框，杜绝网页/二维码 drive-by。
- **M5/L5** 翻译引擎 API key、Trakt/Bangumi sync token 改存 OS 钥匙串加密（SecureCredentialStore 新增通用加密 KV + 迁移 + 回退）。
- **L1** 插件 ctx.http 重定向后校验最终主机仍在白名单。
- **M1** 插件 getCredentials 逐次确认 + 明文密码警告。
- **L2** 同时启用插件数上限 16。
- **L8/L9** Windows 深链单实例转发校验目标进程映像（防伪造窗口拦截）。
- **M6** 桌面三端发布内置 ffmpeg，避免运行时无校验下载。

## 验证
- Dart 侧 `flutter analyze` 全清。
- C++(main.cpp)、CI(build.yml) 由本 PR 的 Actions 编译验证。

🤖 Generated with [Claude Code](https://claude.com/claude-code)