### PR TITLE
fix(desktop): 未加服务器的内容页占位统一引导到服务器管理页

### DIFF
--- a/lib/desktop/shell/desktop_content_gate.dart
+++ b/lib/desktop/shell/desktop_content_gate.dart
@@ -51,9 +51,9 @@ class _NoServerPlaceholder extends StatelessWidget {
           ),
           const SizedBox(height: 20),
           FilledButton.icon(
-            onPressed: () => context.go('/add-server'),
+            onPressed: () => context.go('/servers'),
             icon: const Icon(Icons.add),
-            label: const Text('添加服务器'),
+            label: const Text('前往服务器管理'),
           ),
         ],
       ),


### PR DESCRIPTION
媒体库/收藏/下载的「请先添加服务器」占位按钮原本跳到 /add-server,
与首页空状态引导(跳 /servers)不一致。统一改为「前往服务器管理」→
/servers,与首页一致,符合「提示用户前往服务器页」的预期。

设置页/服务器页本就随时可进(redirect 已放开、Gate 只拦内容页),
此改动仅统一无服务器时的引导落点。