### PR TITLE
feat(desktop): 便携包数据收进 程序目录/userdata(各副本隔离·覆盖更新不丢配置)

### DIFF
--- a/docs/PORTABLE.md
+++ b/docs/PORTABLE.md
@@ -1,0 +1,47 @@
+# 桌面便携包:干净、隔离、可覆盖更新
+
+LinPlayer 的 Windows/Linux 压缩包是**便携包**:所有应用数据都写在**程序目录**内,
+不往系统目录乱丢文件。每份解压目录是一套独立环境 —— 互不影响,适合「同机并存多版本」
+或「本地构建 vs. GitHub 构建对照测试」。
+
+## 解压后的目录结构
+
+```
+LinPlayer/
+├─ linplayer.exe          ← 程序本体
+├─ *.dll                  ← 运行库(libmpv-2.dll、flutter_windows.dll …)
+├─ data/                  ← Flutter 自带资源(flutter_assets、icudtl.dat)※更新时被替换
+├─ plugins/               ← QuickJS 插件
+├─ downloads/             ← 应用内下载
+├─ temp/                  ← 图片/视频缓存(可随时删)
+└─ userdata/              ← 你的全部配置与数据 ★更新时保留★
+   ├─ app_support/        ← 设置、服务器列表、密码/Token(Windows 上 DPAPI 加密)、
+   │                         观看记录、字体、mpv.conf、whisper 模型
+   ├─ documents/          ← 日志导出
+   ├─ cache/              ← 杂项缓存
+   └─ temp/               ← 运行日志、临时文件
+```
+
+> 实现见 `lib/core/services/portable_paths.dart`:启动最早期把
+> `PathProviderPlatform.instance` 重定向到 `程序目录/userdata`。
+
+## 三条保证
+
+1. **干净**:不写 `%APPDATA%`、不写「文档」目录、不进系统钥匙串(Windows)。
+   删掉解压文件夹 = 彻底清除,系统里不留残渣。
+2. **隔离**:每份解压目录只读写**自己的 `userdata/`**。解压两份分别跑 GitHub 包和
+   本地包,配置互不串改 —— 可以放心对照测试整个安装流程。
+3. **可覆盖更新**:更新包(zip)只含程序文件与 `data/`,**不含 `userdata/`**。
+   把新版解压**覆盖**到旧目录即可:程序文件被替换,`userdata/`(及 `plugins/`、
+   `downloads/`)原样保留,配置不丢。
+
+## 边界情况
+
+- **装到只读位置**(如 `C:\Program Files\`):程序目录不可写,启动探针失败 →
+  自动回退到系统默认目录(`%APPDATA%` 等),功能不受影响,只是不再便携。
+- **从旧版升级**:首次以便携方式启动时,若 `userdata/` 是全新创建,会把旧的系统
+  应用支持目录(`%APPDATA%\…`)里的配置**一次性迁移**进 `userdata/app_support`,
+  老用户升级后设置不丢。
+- **Linux 密码存储**:`flutter_secure_storage_linux` 走系统 libsecret 钥匙串
+  (不经 path_provider),故 Linux 上密码/Token 仍在系统钥匙串里;其余数据照样便携。
+  Windows 不受此限(DPAPI 密文文件落在 `userdata/app_support/`)。

--- a/lib/core/services/portable_paths.dart
+++ b/lib/core/services/portable_paths.dart
@@ -1,0 +1,146 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+
+/// 便携化路径:让 Windows/Linux 压缩包版把**所有**应用数据写在「程序目录」内,
+/// 实现「解压即用、各副本互不影响、覆盖更新不丢配置、不污染系统目录」。
+///
+/// 原理:Windows 上 SharedPreferences(设置/服务器列表)、flutter_secure_storage
+/// 的 DPAPI 密文(密码/Token)、观看记录、字体、mpv.conf、whisper 模型、日志,
+/// 几乎全部经由 `path_provider` 的 `getApplicationSupportDirectory` /
+/// `getApplicationDocumentsDirectory` / `getTemporaryDirectory` 落盘。只要在启动
+/// 最早期把 [PathProviderPlatform.instance] 整体重定向到程序目录下的 `userdata/`,
+/// 这些数据就**一处全收**地搬进压缩包文件夹,且密码在 Windows 上仍是 DPAPI 真加密
+/// (无安全降级)。
+///
+/// 触发条件:仅 Windows/Linux 且程序目录可写时启用(与缓存/插件/下载现有便携策略
+/// 一致)。装到只读位置(如 `Program Files`)时探针失败 → 保持系统默认目录,自动回退。
+///
+/// 目录名用 `userdata/` 而非 `data/`:后者是 Flutter Windows 自带资源目录
+/// (flutter_assets/icudtl.dat),覆盖更新需要被替换;`userdata/` 与之分离,
+/// 覆盖更新只动程序文件、不动 `userdata/`,用户配置得以保留。
+///
+/// Linux 注意:`flutter_secure_storage_linux` 走系统 libsecret 钥匙串(不经
+/// path_provider),故 Linux 上密码/Token 仍在系统钥匙串;其余数据照样便携。
+class PortablePathProvider extends PathProviderPlatform {
+  PortablePathProvider._(this._root, this._delegate);
+
+  final String _root;
+  final PathProviderPlatform _delegate;
+
+  static String? _activeRoot;
+
+  /// 已启用便携模式时返回 `userdata/` 根目录;未启用返回 null。
+  static String? get activeRoot => _activeRoot;
+
+  /// 在 [runApp] 与任何 path_provider 调用之前调用一次。
+  ///
+  /// 可行则把全局 PathProvider 重定向进程序目录,并对老用户做一次性
+  /// `%APPDATA%`(旧应用支持目录)→ `userdata/app_support` 的配置迁移。
+  static Future<void> ensureInstalled() async {
+    if (!(Platform.isWindows || Platform.isLinux)) return;
+    if (_activeRoot != null) return;
+
+    final delegate = PathProviderPlatform.instance;
+    String root;
+    bool freshlyCreated;
+    try {
+      final exeDir = File(Platform.resolvedExecutable).parent.path;
+      root = p.join(exeDir, 'userdata');
+      final dir = Directory(root);
+      freshlyCreated = !dir.existsSync();
+      if (freshlyCreated) dir.createSync(recursive: true);
+      // 写探针确认可写;装到只读位置则放弃便携,回退系统目录。
+      final probe = File(p.join(root, '.write_test'));
+      probe.writeAsStringSync('ok');
+      probe.deleteSync();
+    } catch (_) {
+      return; // 不可写 → 保持系统默认目录。
+    }
+
+    final provider = PortablePathProvider._(root, delegate);
+
+    // 老用户迁移:首次创建 userdata 时,把旧应用支持目录的配置整体搬进来,
+    // 避免升级到便携版后「设置全没了」。仅迁一次,失败不阻断启动。
+    if (freshlyCreated) {
+      await _migrateLegacySupport(delegate, provider._sub('app_support'));
+    }
+
+    _activeRoot = root;
+    PathProviderPlatform.instance = provider;
+  }
+
+  /// 把旧的系统应用支持目录(含 SharedPreferences、安全存储密文、观看记录、
+  /// 字体、mpv.conf 等)递归复制进便携目录。仅在目标为空时复制,绝不覆盖。
+  static Future<void> _migrateLegacySupport(
+      PathProviderPlatform delegate, Directory dest) async {
+    try {
+      final oldPath = await delegate.getApplicationSupportPath();
+      if (oldPath == null) return;
+      final oldDir = Directory(oldPath);
+      if (!oldDir.existsSync()) return;
+      if (p.equals(oldDir.path, dest.path)) return;
+      // 目标已有内容则视为已迁移/用户已用过,跳过。
+      if (dest.existsSync() && dest.listSync().isNotEmpty) return;
+      if (!dest.existsSync()) dest.createSync(recursive: true);
+      await _copyDirInto(oldDir, dest);
+    } catch (_) {
+      // 迁移失败就当全新开始,不影响使用。
+    }
+  }
+
+  static Future<void> _copyDirInto(Directory src, Directory dest) async {
+    await for (final entity in src.list(recursive: false, followLinks: false)) {
+      final name = p.basename(entity.path);
+      if (entity is Directory) {
+        final sub = Directory(p.join(dest.path, name));
+        if (!sub.existsSync()) sub.createSync(recursive: true);
+        await _copyDirInto(entity, sub);
+      } else if (entity is File) {
+        try {
+          await entity.copy(p.join(dest.path, name));
+        } catch (_) {
+          // 单个文件(如被占用)复制失败就跳过。
+        }
+      }
+    }
+  }
+
+  Directory _sub(String name) {
+    final d = Directory(p.join(_root, name));
+    if (!d.existsSync()) d.createSync(recursive: true);
+    return d;
+  }
+
+  // ---- 重定向进程序目录的四类应用数据 ----
+  @override
+  Future<String?> getApplicationSupportPath() async => _sub('app_support').path;
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => _sub('documents').path;
+
+  @override
+  Future<String?> getApplicationCachePath() async => _sub('cache').path;
+
+  @override
+  Future<String?> getTemporaryPath() async => _sub('temp').path;
+
+  // ---- 其余交回原实现 ----
+  @override
+  Future<String?> getLibraryPath() => _delegate.getLibraryPath();
+
+  @override
+  Future<String?> getDownloadsPath() => _delegate.getDownloadsPath();
+
+  @override
+  Future<String?> getExternalStoragePath() => _delegate.getExternalStoragePath();
+
+  @override
+  Future<List<String>?> getExternalCachePaths() =>
+      _delegate.getExternalCachePaths();
+
+  @override
+  Future<List<String>?> getExternalStoragePaths({StorageDirectory? type}) =>
+      _delegate.getExternalStoragePaths(type: type);
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,6 +13,7 @@ import 'core/services/crash_diagnostics.dart';
 import 'core/services/secure_credential_store.dart';
 import 'core/services/deep_link_service.dart';
 import 'core/services/font_service.dart';
+import 'core/services/portable_paths.dart';
 import 'core/theme/app_motion.dart';
 import 'core/utils/platform_utils.dart';
 import 'desktop/desktop_app.dart';
@@ -22,6 +23,12 @@ import 'tv/tv_app.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+
+  // 便携化:Windows/Linux 压缩包版把所有应用数据(设置/凭据/记录/日志/缓存)
+  // 重定向进「程序目录/userdata」,实现各副本互不影响、覆盖更新不丢配置、不污染
+  // 系统目录。必须在任何 path_provider 调用(下面 AppLogger/SharedPreferences 等)
+  // 之前完成。装到只读位置时自动回退系统目录。
+  await PortablePathProvider.ensureInstalled();
 
   // 日志：尽早初始化文件落盘 + 捕获未处理异常（三端统一、原生输出、可被 AI 读取）。
   await AppLogger().init();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -797,7 +797,7 @@ packages:
     source: hosted
     version: "2.2.1"
   path_provider_platform_interface:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path_provider_platform_interface
       sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,6 +48,8 @@ dependencies:
   # 工具
   ffi: ^2.2.0
   path_provider: ^2.1.2
+  # 便携化:直接重定向 PathProviderPlatform.instance(见 core/services/portable_paths.dart)
+  path_provider_platform_interface: ^2.1.0
   path: ^1.9.0
   uuid: ^4.3.3
   win32: ^5.15.0


### PR DESCRIPTION
## 目的
让 Windows/Linux 压缩包成为真正干净、独立的便携包:所有应用数据写在**程序目录**内,不污染系统目录;每份解压目录互不影响(可对照测试 GitHub 包 vs 本地包);更新包覆盖解压即更新且保留配置。

## 改动
- 新增 `lib/core/services/portable_paths.dart`:启动最早期把 `PathProviderPlatform.instance` 重定向到 `程序目录/userdata`。Windows 上 SharedPreferences(设置/服务器列表)、flutter_secure_storage 的 DPAPI 密文(密码/Token)、观看记录、字体、mpv.conf、whisper 模型、日志全部经 path_provider 落盘,**一处全收**。
- `lib/main.dart`:在任何 path_provider 调用前 `await PortablePathProvider.ensureInstalled()`。
- `pubspec.yaml`:`path_provider_platform_interface` 转直接依赖。
- 新增 `docs/PORTABLE.md`:便携布局 + 隔离/覆盖更新/干净 三条保证 + 边界情况。

## 保证
- **干净**:不写 `%APPDATA%`/文档/系统钥匙串(Win),删文件夹即彻底清除。
- **隔离**:每份解压目录只读写自己的 `userdata/`。
- **可覆盖更新**:更新包不含 `userdata/`,覆盖解压保留配置。
- Windows 密码仍 DPAPI 真加密,**无安全降级**。
- 只读位置(Program Files)自动回退系统目录;老用户首次便携启动一次性迁移旧 `%APPDATA%` 配置。
- Linux 密码走 libsecret 系统钥匙串(不经 path_provider),仍留钥匙串;其余数据照样便携(已注明)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)