### PR TITLE
feat: 桌面截图HDR修正·三端播放键进度条·集列表上移·弹幕本地导入与面板重构

### DIFF
--- a/lib/core/api/danmaku/danmaku_service.dart
+++ b/lib/core/api/danmaku/danmaku_service.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'dart:async';
 import 'dart:convert';
 import 'danmaku_source.dart';
 import 'danmaku_cache.dart';
@@ -89,6 +90,43 @@ class DanmakuService {
       }
     }));
     return results;
+  }
+
+  /// 流式分源搜索：每个源各自查询，**谁先返回谁先发**（按出现速度从前往后）。
+  /// 用于搜索面板边搜边显示，无需等最慢的源。全部完成后关闭流。
+  Stream<DanmakuSourceGroup> searchAllStreamed(String keyword) {
+    final controller = StreamController<DanmakuSourceGroup>();
+    final srcs = allSources;
+    if (srcs.isEmpty) {
+      controller.close();
+      return controller.stream;
+    }
+    var remaining = srcs.length;
+    void done() {
+      remaining--;
+      if (remaining <= 0 && !controller.isClosed) controller.close();
+    }
+
+    for (final source in srcs) {
+      source.searchEpisodes(anime: keyword).then((r) {
+        if (!controller.isClosed) {
+          controller.add(DanmakuSourceGroup(
+            sourceId: source.config.id,
+            sourceName: source.config.name,
+            animes: r.animes,
+          ));
+        }
+      }).catchError((Object e) {
+        if (!controller.isClosed) {
+          controller.add(DanmakuSourceGroup(
+            sourceId: source.config.id,
+            sourceName: source.config.name,
+            error: e,
+          ));
+        }
+      }).whenComplete(done);
+    }
+    return controller.stream;
   }
 
   /// 并行向所有启用源做文件名/哈希匹配，分源返回候选。

--- a/lib/core/services/mpv_player_adapter.dart
+++ b/lib/core/services/mpv_player_adapter.dart
@@ -2046,9 +2046,39 @@ class MpvPlayerAdapter implements PlayerAdapter {
 
   @override
   Future<Uint8List?> screenshot() async {
-    if (_player == null) return null;
+    final player = _player;
+    if (player == null) return null;
+    // HDR/杜比视界亮度修正：media_kit 的 screenshot() 写死 `screenshot-raw video`，
+    // 截的是解码后的原始帧——不经过 GPU 渲染管线的 tone-mapping/色彩管理，HDR/DV
+    // 片会明显过曝(比屏幕亮)。这里改用 mpv 的 `window` 模式截「渲染后的窗口」(已
+    // tone-map、与屏幕所见一致)，截到临时文件再读回。任一步失败都回退默认实现，
+    // 保证不比原来差。
+    final np = _nativePlayer;
+    if (np != null) {
+      File? shotFile;
+      try {
+        final dir = await getTemporaryDirectory();
+        final path =
+            '${dir.path}${Platform.pathSeparator}linshot_${DateTime.now().microsecondsSinceEpoch}.png';
+        await np.command(['screenshot-to-file', path, 'window']);
+        shotFile = File(path);
+        if (await shotFile.exists()) {
+          final bytes = await shotFile.readAsBytes();
+          if (bytes.isNotEmpty) return bytes;
+        }
+      } catch (e, stackTrace) {
+        _logger.eWithStack(
+            'MpvAdapter', 'window 模式截图失败，回退默认截图', e, stackTrace);
+      } finally {
+        if (shotFile != null) {
+          try {
+            if (await shotFile.exists()) await shotFile.delete();
+          } catch (_) {}
+        }
+      }
+    }
     try {
-      return await _player!.screenshot();
+      return await player.screenshot();
     } catch (e, stackTrace) {
       _logger.eWithStack('MpvAdapter', '截图失败', e, stackTrace);
       return null;

--- a/lib/core/utils/danmaku_local_parser.dart
+++ b/lib/core/utils/danmaku_local_parser.dart
@@ -1,0 +1,211 @@
+import 'dart:convert';
+
+import 'package:xml/xml.dart';
+
+import '../api/api_interfaces.dart';
+
+/// 本地弹幕文件解析：把用户导入的 .xml / .json / .ass 文件转成 [DanmakuItem]。
+///
+/// - **.xml**：B站 / 弹弹Play 导出的 `<d p="time,mode,fontsize,color,...">text</d>` 格式。
+/// - **.json**：弹弹Play 评论 JSON（`{comments:[{p:"time,mode,color,uid", m:"text"}]}`，
+///   或裸数组 / `{data:[...]}`）。
+/// - **.ass**：Aegisub 字幕版弹幕，按 Dialogue 行尽力解析（时间 + 文本 +
+///   `\an8`顶/`\an2`底 位置 + `\c` 颜色），位置/颜色取不到时退化为白色滚动。
+///
+/// 解析失败抛 [FormatException]，调用方据此提示用户。
+class DanmakuLocalParser {
+  /// 支持的扩展名（不含点）。
+  static const supportedExtensions = ['xml', 'json', 'ass', 'ssa'];
+
+  /// 按文件名后缀分派解析。[content] 为文件文本内容。
+  static List<DanmakuItem> parse(String fileName, String content) {
+    final ext = _ext(fileName);
+    switch (ext) {
+      case 'xml':
+        return parseXml(content);
+      case 'json':
+        return parseJson(content);
+      case 'ass':
+      case 'ssa':
+        return parseAss(content);
+      default:
+        // 未知后缀：按内容猜测（XML / JSON）。
+        final trimmed = content.trimLeft();
+        if (trimmed.startsWith('<')) return parseXml(content);
+        if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+          return parseJson(content);
+        }
+        throw const FormatException('无法识别的弹幕文件格式');
+    }
+  }
+
+  static String _ext(String fileName) {
+    final i = fileName.lastIndexOf('.');
+    if (i < 0 || i == fileName.length - 1) return '';
+    return fileName.substring(i + 1).toLowerCase();
+  }
+
+  // ============ XML（B站 / 弹弹Play 导出）============
+
+  /// `<d p="time,mode,fontsize,color,timestamp,pool,senderhash,rowid">text</d>`
+  static List<DanmakuItem> parseXml(String content) {
+    final XmlDocument doc;
+    try {
+      doc = XmlDocument.parse(content);
+    } catch (e) {
+      throw FormatException('XML 解析失败: $e');
+    }
+    final out = <DanmakuItem>[];
+    for (final d in doc.findAllElements('d')) {
+      final p = d.getAttribute('p');
+      final text = d.innerText.trim();
+      if (text.isEmpty) continue;
+      final f = (p ?? '').split(',');
+      final time = f.isNotEmpty ? (double.tryParse(f[0]) ?? 0) : 0;
+      final mode = f.length > 1 ? (int.tryParse(f[1]) ?? 1) : 1;
+      // B站 p：index2=字号, index3=颜色(十进制)。
+      final color = f.length > 3 ? (int.tryParse(f[3]) ?? 16777215) : 16777215;
+      out.add(DanmakuItem(
+        time: time.toDouble(),
+        text: text,
+        type: _normalizeMode(mode),
+        color: color,
+        source: '本地导入',
+      ));
+    }
+    if (out.isEmpty) {
+      throw const FormatException('XML 中未找到弹幕（<d> 节点为空）');
+    }
+    return out;
+  }
+
+  // ============ JSON（弹弹Play 评论）============
+
+  static List<DanmakuItem> parseJson(String content) {
+    final dynamic data;
+    try {
+      data = jsonDecode(content);
+    } catch (e) {
+      throw FormatException('JSON 解析失败: $e');
+    }
+    List<dynamic>? comments;
+    if (data is List) {
+      comments = data;
+    } else if (data is Map) {
+      comments = (data['comments'] ?? data['data'] ?? data['danmuku']) as List?;
+    }
+    if (comments == null) {
+      throw const FormatException('JSON 中未找到弹幕列表（comments/data）');
+    }
+    final out = <DanmakuItem>[];
+    for (final c in comments) {
+      if (c is! Map) continue;
+      // 弹弹Play p：time,mode,color,uid（4 段，无字号）。
+      final p = (c['p'] as String?)?.split(',') ?? const [];
+      final text = (c['m'] ?? c['text'] ?? '').toString();
+      if (text.isEmpty) continue;
+      final time = p.isNotEmpty ? (double.tryParse(p[0]) ?? 0) : 0;
+      final mode = p.length > 1 ? (int.tryParse(p[1]) ?? 1) : 1;
+      final color = p.length > 2 ? (int.tryParse(p[2]) ?? 16777215) : 16777215;
+      out.add(DanmakuItem(
+        time: time.toDouble(),
+        text: text,
+        type: _normalizeMode(mode),
+        color: color,
+        source: '本地导入',
+        cid: c['cid']?.toString(),
+        userId: p.length > 3 ? p[3] : null,
+      ));
+    }
+    if (out.isEmpty) {
+      throw const FormatException('JSON 中没有可用弹幕');
+    }
+    return out;
+  }
+
+  // ============ ASS / SSA（字幕版弹幕，尽力解析）============
+
+  static final _assColorRe = RegExp(r'\\c&H([0-9A-Fa-f]{6,8})&');
+  static final _assOverrideRe = RegExp(r'\{[^}]*\}');
+
+  static List<DanmakuItem> parseAss(String content) {
+    final out = <DanmakuItem>[];
+    for (final raw in const LineSplitter().convert(content)) {
+      final line = raw.trim();
+      if (!line.startsWith('Dialogue:')) continue;
+      // Dialogue: Layer,Start,End,Style,Name,MarginL,MarginR,MarginV,Effect,Text
+      final rest = line.substring('Dialogue:'.length);
+      final parts = rest.split(',');
+      if (parts.length < 10) continue;
+      final start = _parseAssTime(parts[1].trim());
+      if (start == null) continue;
+      // 文本是第 10 段起的全部（文本里可能含逗号，故 join 回来）。
+      final rawText = parts.sublist(9).join(',');
+      // 位置：\an8=顶, \an2/\an1/\an3=底，其余视为滚动。
+      int type = 1;
+      if (rawText.contains(r'\an8') ||
+          rawText.contains(r'\a6') ||
+          rawText.contains(r'\a7')) {
+        type = 5;
+      } else if (rawText.contains(r'\an2') ||
+          rawText.contains(r'\an1') ||
+          rawText.contains(r'\an3')) {
+        type = 4;
+      }
+      // 颜色：取第一个 \c&Hbbggrr&（ASS 是 BGR）。
+      int color = 16777215;
+      final m = _assColorRe.firstMatch(rawText);
+      if (m != null) {
+        final hex = m.group(1)!;
+        final bgr = hex.substring(hex.length - 6);
+        final b = int.parse(bgr.substring(0, 2), radix: 16);
+        final g = int.parse(bgr.substring(2, 4), radix: 16);
+        final r = int.parse(bgr.substring(4, 6), radix: 16);
+        color = (r << 16) | (g << 8) | b;
+      }
+      final text =
+          rawText.replaceAll(_assOverrideRe, '').replaceAll(r'\N', ' ').trim();
+      if (text.isEmpty) continue;
+      out.add(DanmakuItem(
+        time: start,
+        text: text,
+        type: type,
+        color: color,
+        source: '本地导入',
+      ));
+    }
+    if (out.isEmpty) {
+      throw const FormatException('ASS 中未解析到弹幕（Dialogue 行为空）');
+    }
+    out.sort((a, b) => a.time.compareTo(b.time));
+    return out;
+  }
+
+  /// `H:MM:SS.cc` → 秒。
+  static double? _parseAssTime(String s) {
+    final m = RegExp(r'^(\d+):(\d{1,2}):(\d{1,2})(?:[.:](\d{1,3}))?$').firstMatch(s);
+    if (m == null) return null;
+    final h = int.parse(m.group(1)!);
+    final min = int.parse(m.group(2)!);
+    final sec = int.parse(m.group(3)!);
+    final cs = m.group(4);
+    final frac = cs == null ? 0.0 : double.parse('0.$cs');
+    return h * 3600 + min * 60 + sec + frac;
+  }
+
+  /// 把各家弹幕 mode 归一到弹弹Play 标准：1=滚动, 4=底部, 5=顶部。
+  static int _normalizeMode(int mode) {
+    switch (mode) {
+      case 4:
+        return 4; // 底部
+      case 5:
+        return 5; // 顶部
+      case 1:
+      case 2:
+      case 3:
+      case 6:
+      default:
+        return 1; // 滚动（含逆向，渲染层按滚动处理）
+    }
+  }
+}

--- a/lib/desktop/screens/detail/desktop_media_detail_screen_header.dart
+++ b/lib/desktop/screens/detail/desktop_media_detail_screen_header.dart
@@ -741,8 +741,9 @@ class _InfoSectionState extends ConsumerState<_InfoSection> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        // 简介
-        if (widget.item.overview != null &&
+        // 简介（电影：信息在顶部；剧集：下沉到集/季列表之下，让选集更靠前）
+        if (!isSeries &&
+            widget.item.overview != null &&
             widget.item.overview!.isNotEmpty) ...[
           _OverviewSection(
             overview: widget.item.overview!,
@@ -853,6 +854,21 @@ class _InfoSectionState extends ConsumerState<_InfoSection> {
             onSeasonTap: (season) {
               setState(() => _selectedSeasonId = season.id);
             },
+          ),
+          SizedBox(height: 48 * scale),
+        ],
+
+        // 简介（剧集：下沉到选集之下）
+        if (isSeries &&
+            widget.item.overview != null &&
+            widget.item.overview!.isNotEmpty) ...[
+          _OverviewSection(
+            overview: widget.item.overview!,
+            expanded: _overviewExpanded,
+            scaleFactor: scale,
+            accentColor: widget.primaryColor,
+            onToggle: () =>
+                setState(() => _overviewExpanded = !_overviewExpanded),
           ),
           SizedBox(height: 48 * scale),
         ],
@@ -1608,6 +1624,11 @@ class _PlayButtonState extends State<_PlayButton> {
     final scale = widget.scaleFactor;
     final foregroundColor = readableTextColorForBackground(widget.primaryColor);
     final dividerColor = foregroundColor.withValues(alpha: 0.24);
+    final positionTicks = widget.item.userData?.playbackPositionTicks;
+    final runTimeTicks = widget.item.runTimeTicks;
+    final progress = watchedFraction(positionTicks, runTimeTicks);
+    final timeText = formatWatchedOverTotalLabel(positionTicks, runTimeTicks);
+    final hasProgress = progress != null && progress > 0;
 
     return MouseRegion(
       onEnter: (_) => setState(() => _isHovered = true),
@@ -1622,6 +1643,7 @@ class _PlayButtonState extends State<_PlayButton> {
               child: AnimatedContainer(
                 duration: const Duration(milliseconds: 150),
                 height: 48 * scale,
+                clipBehavior: Clip.antiAlias,
                 decoration: BoxDecoration(
                   gradient: LinearGradient(
                     colors: [
@@ -1642,21 +1664,55 @@ class _PlayButtonState extends State<_PlayButton> {
                         ]
                       : null,
                 ),
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
+                child: Stack(
                   children: [
-                    Icon(
-                      Icons.play_arrow,
-                      color: foregroundColor,
-                      size: 24 * scale,
-                    ),
-                    SizedBox(width: 8 * scale),
-                    Text(
-                      '开始播放',
-                      style: TextStyle(
-                        fontSize: 16 * scale,
-                        fontWeight: FontWeight.w600,
-                        color: foregroundColor,
+                    // 底部观看进度填充
+                    if (hasProgress)
+                      Positioned(
+                        left: 0,
+                        right: 0,
+                        bottom: 0,
+                        child: FractionallySizedBox(
+                          alignment: Alignment.centerLeft,
+                          widthFactor: progress.clamp(0.0, 1.0),
+                          child: Container(
+                            height: 4 * scale,
+                            color: foregroundColor.withValues(alpha: 0.5),
+                          ),
+                        ),
+                      ),
+                    Center(
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Icon(
+                            Icons.play_arrow,
+                            color: foregroundColor,
+                            size: 24 * scale,
+                          ),
+                          SizedBox(width: 8 * scale),
+                          Text(
+                            hasProgress ? '继续观看' : '开始播放',
+                            style: TextStyle(
+                              fontSize: 16 * scale,
+                              fontWeight: FontWeight.w600,
+                              color: foregroundColor,
+                            ),
+                          ),
+                          if (timeText != null) ...[
+                            SizedBox(width: 10 * scale),
+                            Text(
+                              timeText,
+                              style: TextStyle(
+                                fontSize: 12.5 * scale,
+                                color: foregroundColor.withValues(alpha: 0.85),
+                                fontFeatures: const [
+                                  FontFeature.tabularFigures()
+                                ],
+                              ),
+                            ),
+                          ],
+                        ],
                       ),
                     ),
                   ],

--- a/lib/tv/screens/detail/tv_detail_screen.dart
+++ b/lib/tv/screens/detail/tv_detail_screen.dart
@@ -94,13 +94,14 @@ class _TvDetailScreenState extends ConsumerState<TvDetailScreen> {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 _buildActionButtons(item, m),
-                if (item.overview != null && item.overview!.isNotEmpty) ...[
-                  SizedBox(height: m.spacingLg),
-                  _buildSynopsis(item.overview!, m),
-                ],
+                // 选集列表放在「简介」之上，方便遥控器直接选集切换。
                 if (isSeries) ...[
                   SizedBox(height: m.spacingLg),
                   _buildSeasonsAndEpisodes(api, item, m),
+                ],
+                if (item.overview != null && item.overview!.isNotEmpty) ...[
+                  SizedBox(height: m.spacingLg),
+                  _buildSynopsis(item.overview!, m),
                 ],
                 SizedBox(height: m.spacingXxl),
               ],
@@ -233,13 +234,44 @@ class _TvDetailScreenState extends ConsumerState<TvDetailScreen> {
     final resumeTicks = item.userData?.playbackPositionTicks ?? 0;
     final hasResume =
         item.type != 'Series' && !(item.userData?.played ?? false) && resumeTicks > 0;
+    final progress = watchedFraction(resumeTicks, item.runTimeTicks);
+    final timeText = formatWatchedOverTotalLabel(resumeTicks, item.runTimeTicks);
+    final showProgress = hasResume && progress != null;
     return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        TvButton(
-          text: hasResume ? '继续观看' : '播放',
-          icon: Icons.play_arrow,
-          autofocus: true,
-          onPressed: () => _onPlayMain(item),
+        // 播放键：键内显示「继续观看 12:34 / 45:00」，键下贴一条等宽观看进度条
+        IntrinsicWidth(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              TvButton(
+                text: hasResume && timeText != null
+                    ? '继续观看  $timeText'
+                    : (hasResume ? '继续观看' : '播放'),
+                icon: Icons.play_arrow,
+                autofocus: true,
+                onPressed: () => _onPlayMain(item),
+              ),
+              if (showProgress) ...[
+                SizedBox(height: m.spacingXs),
+                Padding(
+                  padding: EdgeInsets.symmetric(horizontal: m.spacingSm),
+                  child: ClipRRect(
+                    borderRadius: BorderRadius.circular(999),
+                    child: LinearProgressIndicator(
+                      value: progress,
+                      minHeight: m.s(4),
+                      backgroundColor: TvDesignTokens.surfaceElevated,
+                      valueColor: const AlwaysStoppedAnimation(
+                          TvDesignTokens.brand),
+                    ),
+                  ),
+                ),
+              ],
+            ],
+          ),
         ),
         SizedBox(width: m.spacingMd),
         TvButton(

--- a/lib/tv/screens/player/tv_player_screen.dart
+++ b/lib/tv/screens/player/tv_player_screen.dart
@@ -1,5 +1,8 @@
 import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
 
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -11,6 +14,7 @@ import '../../../core/providers/app_providers.dart';
 import '../../../core/providers/media_providers.dart';
 import '../../../core/providers/sync_providers.dart';
 import '../../../core/utils/danmaku_filter.dart';
+import '../../../core/utils/danmaku_local_parser.dart';
 import '../../../core/utils/danmaku_matcher.dart';
 import '../../../ui/widgets/common/danmaku_overlay.dart';
 import '../../../core/services/player_subtitle_loader.dart';
@@ -443,6 +447,52 @@ class _TvPlayerScreenState extends ConsumerState<TvPlayerScreen> {
     }
   }
 
+  /// 本地导入弹幕文件（.xml/.json/.ass）→ 解析 → 过滤屏蔽词 → 加载。
+  Future<void> _importLocalDanmaku() async {
+    try {
+      final result = await FilePicker.platform.pickFiles(
+        type: FileType.custom,
+        allowedExtensions: DanmakuLocalParser.supportedExtensions,
+        allowMultiple: false,
+        withData: true,
+      );
+      if (result == null || result.files.isEmpty) return;
+      final f = result.files.first;
+      String content;
+      if (f.bytes != null) {
+        content = utf8.decode(f.bytes!, allowMalformed: true);
+      } else if (f.path != null) {
+        content = await File(f.path!).readAsString();
+      } else {
+        _toast('无法读取文件内容');
+        return;
+      }
+      var items = DanmakuLocalParser.parse(f.name, content);
+      final blockwords = ref.read(danmakuBlockwordsProvider);
+      if (blockwords.isNotEmpty) {
+        final filter = DanmakuFilter()..importBlockwords(blockwords);
+        items = items
+            .where((it) => !filter.shouldFilter(it.text, userId: it.userId))
+            .toList();
+      }
+      if (!mounted) return;
+      if (items.isEmpty) {
+        _toast('该文件没有可用弹幕');
+        return;
+      }
+      ref.read(loadedDanmakuProvider.notifier).state = items;
+      if (!ref.read(danmakuEnabledProvider)) {
+        ref.read(danmakuEnabledProvider.notifier).state = true;
+      }
+      _danmakuLoadedEpisodeId = null;
+      _toast('已导入 ${items.length} 条本地弹幕 · ${f.name}');
+    } on FormatException catch (e) {
+      _toast('解析失败: ${e.message}');
+    } catch (e) {
+      _toast('导入失败: $e');
+    }
+  }
+
   void _toast(String msg) {
     if (!mounted) return;
     ScaffoldMessenger.of(context)
@@ -492,6 +542,14 @@ class _TvPlayerScreenState extends ConsumerState<TvPlayerScreen> {
             onTap: () {
               ref.read(danmakuEnabledProvider.notifier).state = !enabled;
               Navigator.pop(ctx);
+            },
+          ),
+          TvPanelOption(
+            title: '本地导入弹幕',
+            subtitle: '.xml / .json / .ass 文件',
+            onTap: () {
+              Navigator.pop(ctx);
+              unawaited(_importLocalDanmaku());
             },
           ),
           if (_danmakuCandidates.isEmpty)

--- a/lib/ui/screens/detail/media_detail_screen.dart
+++ b/lib/ui/screens/detail/media_detail_screen.dart
@@ -77,16 +77,8 @@ class _DetailContentState extends State<_DetailContent> {
             ),
           ),
 
-          // 简介
-          if (widget.item.overview != null && widget.item.overview!.isNotEmpty)
-            SliverToBoxAdapter(
-              child: _OverviewSection(
-                overview: widget.item.overview!,
-                textColor: foregroundColor,
-              ),
-            ),
-
-          // 剧集相关区块（季 + 集；集数走懒加载 Sliver，几百集也只构建可视项）
+          // 剧集相关区块（季 + 集；集数走懒加载 Sliver，几百集也只构建可视项）。
+          // 放在「简介」之上，方便用户进集详情页就能直接切换集，不用先滑过信息区。
           if (widget.item.type == 'Series') ...[
             _SeasonsSliver(
               itemId: widget.itemId,
@@ -97,6 +89,15 @@ class _DetailContentState extends State<_DetailContent> {
               onEpisodeTap: (episode) => context.push('/episode/${episode.id}'),
             ),
           ],
+
+          // 简介（媒体信息栏）
+          if (widget.item.overview != null && widget.item.overview!.isNotEmpty)
+            SliverToBoxAdapter(
+              child: _OverviewSection(
+                overview: widget.item.overview!,
+                textColor: foregroundColor,
+              ),
+            ),
 
           // 电影播放选项 + 按钮
           if (widget.item.type == 'Movie') ...[
@@ -905,9 +906,8 @@ class _MoviePlaybackSection extends ConsumerWidget {
             itemId: itemId,
             info: info,
           ),
-          _WatchedProgressLabel(itemId: itemId),
           Padding(
-            padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+            padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
             child: _MoviePlayButtons(itemId: itemId),
           ),
           _VersionInfoSection(itemId: itemId),
@@ -922,32 +922,85 @@ class _MoviePlaybackSection extends ConsumerWidget {
   }
 }
 
-/// 播放键上方的「已观看 XX:XX」进度提示（无进度时不显示）。
-class _WatchedProgressLabel extends ConsumerWidget {
-  final String itemId;
+/// 播放键：底部叠加观看进度条 + 键内显示「已观看 / 总时长」。
+/// 有进度时文案为「继续观看」并显示时间，无进度时为「播放」。
+class _PlayButtonWithProgress extends StatelessWidget {
+  final double? progress; // 0~1，null 表示无进度
+  final String? timeText; // 「12:34 / 45:00」，null 表示不显示
+  final VoidCallback onPressed;
 
-  const _WatchedProgressLabel({required this.itemId});
+  const _PlayButtonWithProgress({
+    required this.progress,
+    required this.timeText,
+    required this.onPressed,
+  });
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final label = ref.watch(mediaItemProvider(itemId)).maybeWhen(
-          data: (item) =>
-              formatWatchedProgressLabel(item.userData?.playbackPositionTicks),
-          orElse: () => null,
-        );
-    if (label == null) return const SizedBox.shrink();
-    final color = Theme.of(context).textTheme.bodySmall?.color;
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 10, 16, 0),
-      child: Row(
-        children: [
-          Icon(Icons.history, size: 15, color: color),
-          const SizedBox(width: 6),
-          Text(
-            label,
-            style: TextStyle(fontSize: 12.5, color: color),
-          ),
-        ],
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final hasProgress = progress != null && progress! > 0;
+    return SizedBox(
+      height: 48,
+      child: Material(
+      color: scheme.primary,
+      borderRadius: BorderRadius.circular(8),
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: onPressed,
+        child: Stack(
+          children: [
+            // 底部观看进度填充
+            if (hasProgress)
+              Positioned(
+                left: 0,
+                right: 0,
+                bottom: 0,
+                child: FractionallySizedBox(
+                  alignment: Alignment.centerLeft,
+                  widthFactor: progress!.clamp(0.0, 1.0),
+                  child: Container(
+                    height: 4,
+                    color: scheme.onPrimary.withValues(alpha: 0.55),
+                  ),
+                ),
+              ),
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 13, horizontal: 12),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(Icons.play_arrow, color: scheme.onPrimary, size: 20),
+                  const SizedBox(width: 6),
+                  Flexible(
+                    child: Text(
+                      hasProgress ? '继续观看' : '播放',
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        color: scheme.onPrimary,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ),
+                  if (timeText != null) ...[
+                    const SizedBox(width: 8),
+                    Text(
+                      timeText!,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        color: scheme.onPrimary.withValues(alpha: 0.82),
+                        fontSize: 12,
+                        fontFeatures: const [FontFeature.tabularFigures()],
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
       ),
     );
   }
@@ -962,33 +1015,39 @@ class _MoviePlayButtons extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final mediaSourceId = ref.watch(selectedMediaSourceProvider);
-    final canDownload = ref.watch(mediaItemProvider(itemId)).maybeWhen(
-          data: (item) => item.canDownload ?? false,
-          orElse: () => false,
-        );
+    final item = ref.watch(mediaItemProvider(itemId)).valueOrNull;
+    final canDownload = item?.canDownload ?? false;
+    final progress =
+        watchedFraction(item?.userData?.playbackPositionTicks, item?.runTimeTicks);
+    final timeText = formatWatchedOverTotalLabel(
+        item?.userData?.playbackPositionTicks, item?.runTimeTicks);
     return Row(
       children: [
         Expanded(
           flex: 5,
-          child: FilledButton.icon(
+          child: _PlayButtonWithProgress(
+            progress: progress,
+            timeText: timeText,
             onPressed: () => context.push(
               mediaSourceId != null && mediaSourceId.isNotEmpty
                   ? '/player/$itemId?mediaSourceId=$mediaSourceId'
                   : '/player/$itemId',
-            ),
-            icon: const Icon(Icons.play_arrow),
-            label: const Text('播放'),
-            style: FilledButton.styleFrom(
-              padding: const EdgeInsets.symmetric(vertical: 14),
             ),
           ),
         ),
         const SizedBox(width: 8),
         Expanded(
           flex: 1,
-          child: OutlinedButton(
-            onPressed: () => _showMoreMenu(context, ref, canDownload: canDownload),
-            child: const Icon(Icons.more_vert),
+          child: SizedBox(
+            height: 48,
+            child: OutlinedButton(
+              onPressed: () =>
+                  _showMoreMenu(context, ref, canDownload: canDownload),
+              style: OutlinedButton.styleFrom(
+                padding: EdgeInsets.zero,
+              ),
+              child: const Icon(Icons.more_vert),
+            ),
           ),
         ),
       ],

--- a/lib/ui/utils/media_helpers.dart
+++ b/lib/ui/utils/media_helpers.dart
@@ -50,15 +50,44 @@ Color readableTextColorForBackground(Color background) {
 /// 已观看进度文案：返回如「已观看 12:34」/「已观看 1:02:03」；无有效进度返回 null。
 /// [positionTicks] 为 Emby 的 100ns 单位（10,000,000 ticks = 1 秒）。
 String? formatWatchedProgressLabel(num? positionTicks) {
-  if (positionTicks == null || positionTicks <= 0) return null;
-  final totalSeconds = positionTicks ~/ 10000000;
+  final time = formatTicksClock(positionTicks);
+  if (time == null) return null;
+  return '已观看 $time';
+}
+
+/// 把 Emby 100ns ticks 格式化为时钟字符串：「12:34」/「1:02:03」；无效返回 null。
+String? formatTicksClock(num? ticks) {
+  if (ticks == null || ticks <= 0) return null;
+  final totalSeconds = ticks ~/ 10000000;
   if (totalSeconds <= 0) return null;
   final h = totalSeconds ~/ 3600;
   final m = (totalSeconds % 3600) ~/ 60;
   final s = totalSeconds % 60;
   String two(int v) => v.toString().padLeft(2, '0');
-  final time = h > 0 ? '$h:${two(m)}:${two(s)}' : '$m:${two(s)}';
-  return '已观看 $time';
+  return h > 0 ? '$h:${two(m)}:${two(s)}' : '$m:${two(s)}';
+}
+
+/// 播放键上的「已观看 / 总时长」文案：如「12:34 / 45:00」。
+/// 无有效进度返回 null（此时按钮显示默认「播放」文案）。
+String? formatWatchedOverTotalLabel(num? positionTicks, num? runTimeTicks) {
+  final watched = formatTicksClock(positionTicks);
+  if (watched == null) return null;
+  final total = formatTicksClock(runTimeTicks);
+  return total == null ? watched : '$watched / $total';
+}
+
+/// 观看进度比例 0.0~1.0；无有效进度返回 null。
+/// 末尾 >98% 视为「即将看完」仍返回真实比例（是否清零由调用方决定）。
+double? watchedFraction(num? positionTicks, num? runTimeTicks) {
+  if (positionTicks == null ||
+      runTimeTicks == null ||
+      positionTicks <= 0 ||
+      runTimeTicks <= 0) {
+    return null;
+  }
+  final f = positionTicks / runTimeTicks;
+  if (f <= 0) return null;
+  return f.clamp(0.0, 1.0).toDouble();
 }
 
 Color readableSecondaryTextColorForBackground(Color background) {

--- a/lib/ui/widgets/common/danmaku_search_widget.dart
+++ b/lib/ui/widgets/common/danmaku_search_widget.dart
@@ -1,13 +1,24 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/api/api_interfaces.dart';
 import '../../../core/api/danmaku/danmaku_service.dart';
 import '../../../core/providers/app_providers.dart';
 import '../../../core/utils/danmaku_filter.dart';
+import '../../../core/utils/danmaku_local_parser.dart';
 import '../../../core/utils/danmaku_matcher.dart';
 
-/// 弹幕搜索/匹配面板：并行向所有启用源查询、**分源展示**，用户自己挑。
-/// 移动端在播放器右侧面板使用，桌面端在弹层中复用。
+/// 弹幕搜索/选择面板（移动端右侧面板、桌面端弹层复用）。
+///
+/// 交互：顶部搜索框 → 回车/点搜索 → 各源**流式分源**返回（谁快谁先显示）。
+/// 结果按「剧 / 电影」区分：电影点一下直接加载；剧点进去选集。同一部剧若有
+/// 多个源（danmu_api / 御坂这类聚合器对一部剧会返回多个上游源），点某集后在该
+/// 集下面展开**源下拉**让用户挑；弹弹Play 这种单源则点了直接加载。
+/// 另提供「本地导入」直接加载用户的 .xml/.json/.ass 弹幕文件。
 class DanmakuSearchContent extends ConsumerStatefulWidget {
   final MediaItem? item;
   const DanmakuSearchContent({super.key, this.item});
@@ -27,13 +38,13 @@ class _DanmakuSearchContentState extends ConsumerState<DanmakuSearchContent> {
 
   bool _isSearching = false;
   bool _isBgmtvSearching = false;
-  List<DanmakuSourceGroup> _groups = [];
+  bool _isImporting = false;
+  StreamSubscription<DanmakuSourceGroup>? _searchSub;
 
-  // 当前展开的作品（携带来源）。
-  DanmakuAnime? _selectedAnime;
-  String? _selectedSourceId;
-  String? _selectedSourceName;
-  List<DanmakuEpisode> _selectedEpisodes = [];
+  // 搜索结果按「剧/电影」归组（同标题的多个源合并成一个 show）。
+  final List<_DanmakuShow> _shows = [];
+  String? _expandedShowKey; // 当前展开的剧
+  String? _expandedEpKey; // 当前展开了「源下拉」的集
 
   String? _loadingEpisodeId; // 正在取评论的集
 
@@ -49,12 +60,13 @@ class _DanmakuSearchContentState extends ConsumerState<DanmakuSearchContent> {
 
   @override
   void dispose() {
+    _searchSub?.cancel();
     _searchController.dispose();
     _bgmtvIdController.dispose();
     super.dispose();
   }
 
-  // ============ 智能自动匹配（并行所有源）============
+  // ============ 智能自动匹配（并行所有源，作为推荐）============
 
   Future<void> _runAutoMatch() async {
     final item = widget.item;
@@ -83,44 +95,76 @@ class _DanmakuSearchContentState extends ConsumerState<DanmakuSearchContent> {
       }
     } catch (_) {}
 
-    // 回退到关键词分源搜索。
+    // 回退到关键词流式搜索。
     if (!mounted) return;
     _searchController.text = title;
-    await _search(keyword: title, fromAuto: true);
+    _search(keyword: title, fromAuto: true);
   }
 
-  // ============ 关键词分源搜索 ============
+  // ============ 关键词流式分源搜索 ============
 
-  Future<void> _search({String? keyword, bool fromAuto = false}) async {
+  void _search({String? keyword, bool fromAuto = false}) {
     final kw = (keyword ?? _searchController.text).trim();
     if (kw.isEmpty) return;
+    _searchSub?.cancel();
     setState(() {
       _isSearching = true;
-      if (!fromAuto) _isAutoMatching = false;
-      _selectedAnime = null;
-      _selectedEpisodes = [];
+      _isAutoMatching = false;
+      _shows.clear();
+      _expandedShowKey = null;
+      _expandedEpKey = null;
+      if (!fromAuto) {
+        _autoCandidates = [];
+        _autoMatchStatus = null;
+      }
     });
-    try {
-      final service = ref.read(danmakuServiceProvider);
-      final groups = await service.searchAllGrouped(kw);
-      if (!mounted) return;
-      setState(() {
-        _groups = groups;
-        _isSearching = false;
-        _isAutoMatching = false;
-        if (fromAuto) {
-          final any = groups.any((g) => g.animes.isNotEmpty);
-          _autoMatchStatus = any ? null : '未找到弹幕，请手动搜索或填 Bangumi ID';
-        }
-      });
-    } catch (_) {
-      if (mounted) {
+    final service = ref.read(danmakuServiceProvider);
+    _searchSub = service.searchAllStreamed(kw).listen(
+      (group) {
+        if (!mounted) return;
+        if (group.animes.isEmpty) return;
+        setState(() => _mergeAnimes(group.animes));
+      },
+      onDone: () {
+        if (!mounted) return;
         setState(() {
           _isSearching = false;
-          _isAutoMatching = false;
+          if (_shows.isEmpty) {
+            _autoMatchStatus = '未找到弹幕，请换关键词或填 Bangumi ID';
+          }
         });
+      },
+      onError: (_) {
+        if (mounted) setState(() => _isSearching = false);
+      },
+    );
+  }
+
+  /// 把一批 anime 合并进 [_shows]：按归一化标题聚成「剧」，同剧的不同源累加。
+  void _mergeAnimes(List<DanmakuAnime> animes) {
+    for (final a in animes) {
+      final key = _normalizeTitle(a.animeTitle);
+      if (key.isEmpty) continue;
+      final existing = _findShow(key);
+      if (existing != null) {
+        final dup = existing.sources.any(
+            (x) => x.animeId == a.animeId && x.sourceId == a.sourceId);
+        if (!dup) existing.sources.add(a);
+      } else {
+        _shows.add(_DanmakuShow(
+          key: key,
+          title: _baseTitle(a.animeTitle),
+          sources: [a],
+        ));
       }
     }
+  }
+
+  _DanmakuShow? _findShow(String key) {
+    for (final s in _shows) {
+      if (s.key == key) return s;
+    }
+    return null;
   }
 
   Future<void> _searchByBgmtvId(String idStr) async {
@@ -144,18 +188,63 @@ class _DanmakuSearchContentState extends ConsumerState<DanmakuSearchContent> {
       if (!mounted) return;
       setState(() {
         _isBgmtvSearching = false;
-        _selectedAnime = anime;
-        _selectedSourceId = anime.sourceId ?? 'dandanplay';
-        _selectedSourceName = anime.sourceName ?? '弹弹Play';
-        _selectedEpisodes = anime.episodes ?? [];
-        _groups = [];
+        _shows.clear();
+        _mergeAnimes([anime]);
+        _expandedShowKey = _normalizeTitle(anime.animeTitle);
         _autoCandidates = [];
+        _autoMatchStatus = null;
       });
     } catch (e) {
       if (mounted) {
         setState(() => _isBgmtvSearching = false);
         _toast('Bangumi 搜索失败: $e');
       }
+    }
+  }
+
+  // ============ 本地导入 ============
+
+  Future<void> _importLocal() async {
+    if (_isImporting) return;
+    setState(() => _isImporting = true);
+    try {
+      final result = await FilePicker.platform.pickFiles(
+        type: FileType.custom,
+        allowedExtensions: DanmakuLocalParser.supportedExtensions,
+        allowMultiple: false,
+        withData: true,
+      );
+      if (result == null || result.files.isEmpty) {
+        if (mounted) setState(() => _isImporting = false);
+        return;
+      }
+      final f = result.files.first;
+      String content;
+      if (f.bytes != null) {
+        content = utf8.decode(f.bytes!, allowMalformed: true);
+      } else if (f.path != null) {
+        content = await File(f.path!).readAsString();
+      } else {
+        if (mounted) setState(() => _isImporting = false);
+        _toast('无法读取文件内容');
+        return;
+      }
+      var items = DanmakuLocalParser.parse(f.name, content);
+      items = _applyFilterAndDedup(items);
+      if (!mounted) return;
+      setState(() => _isImporting = false);
+      if (items.isEmpty) {
+        _toast('该文件没有可用弹幕');
+      } else {
+        ref.read(loadedDanmakuProvider.notifier).state = items;
+        _toast('已导入 ${items.length} 条本地弹幕 · ${f.name}');
+      }
+    } on FormatException catch (e) {
+      if (mounted) setState(() => _isImporting = false);
+      _toast('解析失败: ${e.message}');
+    } catch (e) {
+      if (mounted) setState(() => _isImporting = false);
+      _toast('导入失败: $e');
     }
   }
 
@@ -170,19 +259,7 @@ class _DanmakuSearchContentState extends ConsumerState<DanmakuSearchContent> {
     try {
       final service = ref.read(danmakuServiceProvider);
       var items = await service.getComments(episodeId, sourceId: sourceId);
-
-      final blockwords = ref.read(danmakuBlockwordsProvider);
-      if (blockwords.isNotEmpty) {
-        final filter = DanmakuFilter()..importBlockwords(blockwords);
-        items = items
-            .where((it) => !filter.shouldFilter(it.text, userId: it.userId))
-            .toList();
-      }
-
-      if (ref.read(danmakuDedupProvider)) {
-        items = _deduplicateDanmaku(items, ref.read(danmakuDedupWindowProvider));
-      }
-
+      items = _applyFilterAndDedup(items);
       if (!mounted) return;
       setState(() => _loadingEpisodeId = null);
       if (items.isEmpty) {
@@ -197,6 +274,21 @@ class _DanmakuSearchContentState extends ConsumerState<DanmakuSearchContent> {
         _toast('加载弹幕失败: $e');
       }
     }
+  }
+
+  List<DanmakuItem> _applyFilterAndDedup(List<DanmakuItem> input) {
+    var items = input;
+    final blockwords = ref.read(danmakuBlockwordsProvider);
+    if (blockwords.isNotEmpty) {
+      final filter = DanmakuFilter()..importBlockwords(blockwords);
+      items = items
+          .where((it) => !filter.shouldFilter(it.text, userId: it.userId))
+          .toList();
+    }
+    if (ref.read(danmakuDedupProvider)) {
+      items = _deduplicateDanmaku(items, ref.read(danmakuDedupWindowProvider));
+    }
+    return items;
   }
 
   List<DanmakuItem> _deduplicateDanmaku(
@@ -243,34 +335,39 @@ class _DanmakuSearchContentState extends ConsumerState<DanmakuSearchContent> {
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
+        _buildSearchBox(),
+        const SizedBox(height: 8),
+        _buildLocalImportButton(),
+        const SizedBox(height: 8),
+        _buildBgmtvBox(),
         if (_isAutoMatching) _buildAutoMatchingRow(),
         if (_autoCandidates.isNotEmpty) ...[
-          const SizedBox(height: 4),
+          const SizedBox(height: 6),
           const Text('推荐匹配（按可信度）', style: _white54),
-          const SizedBox(height: 4),
+          const SizedBox(height: 2),
           ..._autoCandidates.take(8).map(_buildCandidateTile),
           const Divider(color: Colors.white12),
         ],
-        _buildSearchBox(),
-        const SizedBox(height: 6),
-        _buildBgmtvBox(),
-        if (_autoMatchStatus != null && !_isAutoMatching)
+        if (_autoMatchStatus != null && !_isAutoMatching && _shows.isEmpty)
           Padding(
             padding: const EdgeInsets.symmetric(vertical: 10),
             child: Text(_autoMatchStatus!, style: _white54),
           ),
         if (_isSearching)
           const Padding(
-            padding: EdgeInsets.all(16),
-            child: Center(
-              child: SizedBox(
-                  width: 22,
-                  height: 22,
-                  child: CircularProgressIndicator(strokeWidth: 2)),
+            padding: EdgeInsets.all(12),
+            child: Row(
+              children: [
+                SizedBox(
+                    width: 16,
+                    height: 16,
+                    child: CircularProgressIndicator(strokeWidth: 2)),
+                SizedBox(width: 10),
+                Text('搜索中，结果陆续显示…', style: _white54),
+              ],
             ),
           ),
-        ..._buildGroupedResults(),
-        if (_selectedEpisodes.isNotEmpty) _buildEpisodePicker(),
+        ..._shows.map(_buildShowTile),
       ],
     );
   }
@@ -324,8 +421,9 @@ class _DanmakuSearchContentState extends ConsumerState<DanmakuSearchContent> {
     return TextField(
       controller: _searchController,
       style: const TextStyle(color: Colors.white),
+      textInputAction: TextInputAction.search,
       decoration: InputDecoration(
-        hintText: '搜索动漫/剧集名称',
+        hintText: '搜索剧 / 电影名称',
         hintStyle: const TextStyle(color: Colors.white38),
         prefixIcon: const Icon(Icons.search, color: Colors.white54),
         suffixIcon: _isSearching
@@ -347,6 +445,24 @@ class _DanmakuSearchContentState extends ConsumerState<DanmakuSearchContent> {
         ),
       ),
       onSubmitted: (_) => _search(),
+    );
+  }
+
+  Widget _buildLocalImportButton() {
+    return OutlinedButton.icon(
+      onPressed: _isImporting ? null : _importLocal,
+      icon: _isImporting
+          ? const SizedBox(
+              width: 16,
+              height: 16,
+              child: CircularProgressIndicator(strokeWidth: 2))
+          : const Icon(Icons.upload_file, color: _accent, size: 20),
+      label: const Text('本地导入弹幕（.xml/.json/.ass）',
+          style: TextStyle(color: _accent, fontSize: 13)),
+      style: OutlinedButton.styleFrom(
+        side: const BorderSide(color: _accent),
+        padding: const EdgeInsets.symmetric(vertical: 10),
+      ),
     );
   }
 
@@ -382,8 +498,9 @@ class _DanmakuSearchContentState extends ConsumerState<DanmakuSearchContent> {
                   height: 16,
                   child: CircularProgressIndicator(strokeWidth: 2))
               : const Icon(Icons.link, color: _accent, size: 20),
-          onPressed:
-              _isBgmtvSearching ? null : () => _searchByBgmtvId(_bgmtvIdController.text),
+          onPressed: _isBgmtvSearching
+              ? null
+              : () => _searchByBgmtvId(_bgmtvIdController.text),
           padding: EdgeInsets.zero,
           constraints: const BoxConstraints(minWidth: 36, minHeight: 36),
         ),
@@ -391,99 +508,225 @@ class _DanmakuSearchContentState extends ConsumerState<DanmakuSearchContent> {
     );
   }
 
-  List<Widget> _buildGroupedResults() {
-    if (_groups.isEmpty) return const [];
-    final widgets = <Widget>[];
-    for (final g in _groups) {
-      if (g.animes.isEmpty && g.error == null) continue;
-      widgets.add(Padding(
-        padding: const EdgeInsets.only(top: 10, bottom: 2),
-        child: Row(
-          children: [
-            _sourceChip(g.sourceName),
-            const SizedBox(width: 8),
-            Text(
-              g.error != null
-                  ? '请求失败'
-                  : '${g.animes.length} 个结果',
-              style: _white54,
-            ),
-          ],
-        ),
-      ));
-      for (final anime in g.animes) {
-        final selected = _selectedAnime?.animeId == anime.animeId &&
-            _selectedSourceId == g.sourceId;
-        widgets.add(ListTile(
-          dense: true,
-          title: Text(anime.animeTitle,
-              style: const TextStyle(color: Colors.white, fontSize: 14),
-              maxLines: 2,
-              overflow: TextOverflow.ellipsis),
-          subtitle: Text(
-            '${anime.typeDescription ?? ''} ${anime.year?.toString() ?? ''}'
-                .trim(),
-            style: _white54,
-            maxLines: 2,
-            overflow: TextOverflow.ellipsis,
-          ),
-          trailing: Icon(
-            selected ? Icons.expand_less : Icons.chevron_right,
-            color: Colors.white38,
-          ),
-          selected: selected,
-          selectedTileColor: Colors.white10,
-          onTap: () {
-            setState(() {
-              _selectedAnime = anime;
-              _selectedSourceId = g.sourceId;
-              _selectedSourceName = g.sourceName;
-              _selectedEpisodes = anime.episodes ?? [];
-            });
-          },
-        ));
-      }
-    }
-    return widgets;
-  }
+  // ---- 结果：剧 / 电影 ----
 
-  Widget _buildEpisodePicker() {
+  Widget _buildShowTile(_DanmakuShow show) {
+    final isMovie = show.isMovie;
+    final expanded = _expandedShowKey == show.key;
+    final multiSource = show.sources.length > 1;
+    final subtitle = [
+      isMovie ? '电影' : '剧集',
+      if (multiSource) '${show.sources.length} 个源',
+      if (show.sources.first.year != null) '${show.sources.first.year}',
+    ].join(' · ');
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        const Divider(color: Colors.white12),
-        Row(
-          children: [
-            const Text('选择集数', style: _white54),
-            const SizedBox(width: 8),
-            if (_selectedSourceName != null) _sourceChip(_selectedSourceName!),
-          ],
+        ListTile(
+          dense: true,
+          leading: _kindChip(isMovie),
+          title: Text(show.title,
+              style: const TextStyle(color: Colors.white, fontSize: 14),
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis),
+          subtitle: Text(subtitle, style: _white54),
+          trailing: Icon(
+            isMovie && !multiSource
+                ? Icons.play_circle_outline
+                : (expanded ? Icons.expand_less : Icons.chevron_right),
+            color: isMovie && !multiSource ? _accent : Colors.white38,
+          ),
+          selected: expanded,
+          selectedTileColor: Colors.white10,
+          onTap: () {
+            if (isMovie && !multiSource) {
+              _loadMovie(show.sources.first);
+            } else {
+              setState(() {
+                _expandedShowKey = expanded ? null : show.key;
+                _expandedEpKey = null;
+              });
+            }
+          },
         ),
-        const SizedBox(height: 4),
-        ..._selectedEpisodes.map((ep) {
-          final loading = _loadingEpisodeId == ep.episodeId;
-          return ListTile(
+        if (expanded && isMovie && multiSource) ..._buildMovieSources(show),
+        if (expanded && !isMovie) ..._buildEpisodeList(show),
+      ],
+    );
+  }
+
+  /// 电影多源：每个源点一下直接加载。
+  List<Widget> _buildMovieSources(_DanmakuShow show) {
+    return [
+      for (final a in show.sources)
+        Padding(
+          padding: const EdgeInsets.only(left: 16),
+          child: ListTile(
             dense: true,
-            title: Text(ep.episodeTitle,
-                style: const TextStyle(color: Colors.white, fontSize: 14),
-                maxLines: 2,
-                overflow: TextOverflow.ellipsis),
-            trailing: loading
+            leading: const Icon(Icons.subdirectory_arrow_right,
+                color: Colors.white38, size: 18),
+            title: Text(_sourceLabel(a),
+                style: const TextStyle(color: Colors.white, fontSize: 13)),
+            trailing: _loadingEpisodeId == _movieEpisodeId(a)
                 ? const SizedBox(
                     width: 18,
                     height: 18,
                     child: CircularProgressIndicator(strokeWidth: 2))
                 : const Icon(Icons.download, color: _accent, size: 20),
-            onTap: loading
-                ? null
-                : () => _loadComments(
-                      episodeId: ep.episodeId,
-                      sourceId: ep.sourceId ?? _selectedSourceId,
-                      animeTitle: _selectedAnime?.animeTitle ?? '',
-                    ),
+            onTap: () => _loadMovie(a),
+          ),
+        ),
+    ];
+  }
+
+  List<Widget> _buildEpisodeList(_DanmakuShow show) {
+    final options = _buildEpisodeOptions(show);
+    if (options.isEmpty) {
+      return const [
+        Padding(
+          padding: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          child: Text('该剧暂无可选集', style: _white54),
+        ),
+      ];
+    }
+    final widgets = <Widget>[];
+    for (final opt in options) {
+      final multi = opt.sources.length > 1;
+      final epExpanded = _expandedEpKey == opt.key;
+      final single = opt.sources.first;
+      final loading = !multi && _loadingEpisodeId == single.episode.episodeId;
+      widgets.add(Padding(
+        padding: const EdgeInsets.only(left: 8),
+        child: ListTile(
+          dense: true,
+          title: Text(opt.label,
+              style: const TextStyle(color: Colors.white, fontSize: 14),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis),
+          subtitle: multi ? Text('${opt.sources.length} 个源', style: _white54) : null,
+          trailing: loading
+              ? const SizedBox(
+                  width: 18,
+                  height: 18,
+                  child: CircularProgressIndicator(strokeWidth: 2))
+              : Icon(
+                  multi
+                      ? (epExpanded ? Icons.expand_less : Icons.arrow_drop_down)
+                      : Icons.download,
+                  color: _accent,
+                  size: 20),
+          onTap: () {
+            if (multi) {
+              setState(() => _expandedEpKey = epExpanded ? null : opt.key);
+            } else {
+              _loadComments(
+                episodeId: single.episode.episodeId,
+                sourceId: single.anime.sourceId,
+                animeTitle: single.anime.animeTitle,
+              );
+            }
+          },
+        ),
+      ));
+      // 多源：在该集下面展开源下拉
+      if (multi && epExpanded) {
+        for (final s in opt.sources) {
+          final sLoading = _loadingEpisodeId == s.episode.episodeId;
+          widgets.add(Padding(
+            padding: const EdgeInsets.only(left: 32),
+            child: ListTile(
+              dense: true,
+              leading: const Icon(Icons.subdirectory_arrow_right,
+                  color: Colors.white38, size: 18),
+              title: Text(_sourceLabel(s.anime),
+                  style: const TextStyle(color: Colors.white, fontSize: 13)),
+              trailing: sLoading
+                  ? const SizedBox(
+                      width: 18,
+                      height: 18,
+                      child: CircularProgressIndicator(strokeWidth: 2))
+                  : const Icon(Icons.download, color: _accent, size: 20),
+              onTap: () => _loadComments(
+                episodeId: s.episode.episodeId,
+                sourceId: s.anime.sourceId,
+                animeTitle: s.anime.animeTitle,
+              ),
+            ),
+          ));
+        }
+      }
+    }
+    return widgets;
+  }
+
+  void _loadMovie(DanmakuAnime a) {
+    final epId = _movieEpisodeId(a);
+    if (epId == null) {
+      _toast('该源无可加载的弹幕');
+      return;
+    }
+    _loadComments(
+      episodeId: epId,
+      sourceId: a.sourceId,
+      animeTitle: a.animeTitle,
+    );
+  }
+
+  String? _movieEpisodeId(DanmakuAnime a) {
+    final eps = a.episodes;
+    if (eps == null || eps.isEmpty) return null;
+    return eps.first.episodeId;
+  }
+
+  /// 合并一部剧各源的分集，按集号归并；同一集号下各源即为可选「源」。
+  List<_EpOption> _buildEpisodeOptions(_DanmakuShow show) {
+    final map = <String, _EpOption>{};
+    final order = <String>[];
+    for (final a in show.sources) {
+      for (final ep in a.episodes ?? const <DanmakuEpisode>[]) {
+        final num = ep.episodeNumber?.trim();
+        final key = (num != null && num.isNotEmpty)
+            ? 'n:$num'
+            : 't:${ep.episodeTitle}';
+        final opt = map.putIfAbsent(key, () {
+          order.add(key);
+          return _EpOption(
+            key: key,
+            number: num,
+            label: ep.episodeTitle.isNotEmpty
+                ? ep.episodeTitle
+                : '第 ${num ?? '?'} 集',
+            sources: [],
           );
-        }),
-      ],
+        });
+        opt.sources.add(_EpSource(anime: a, episode: ep));
+      }
+    }
+    final list = order.map((k) => map[k]!).toList();
+    list.sort((x, y) {
+      final nx = int.tryParse(
+          RegExp(r'\d+').firstMatch(x.number ?? '')?.group(0) ?? '');
+      final ny = int.tryParse(
+          RegExp(r'\d+').firstMatch(y.number ?? '')?.group(0) ?? '');
+      if (nx != null && ny != null) return nx.compareTo(ny);
+      return 0;
+    });
+    return list;
+  }
+
+  // ---- 小工具 ----
+
+  Widget _kindChip(bool isMovie) {
+    final color = isMovie ? const Color(0xFFE5A23B) : _accent;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.2),
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Text(isMovie ? '电影' : '剧',
+          style: TextStyle(color: color, fontSize: 12)),
     );
   }
 
@@ -494,8 +737,72 @@ class _DanmakuSearchContentState extends ConsumerState<DanmakuSearchContent> {
         color: _accent.withValues(alpha: 0.2),
         borderRadius: BorderRadius.circular(10),
       ),
-      child: Text(name,
-          style: const TextStyle(color: _accent, fontSize: 11)),
+      child: Text(name, style: const TextStyle(color: _accent, fontSize: 11)),
     );
   }
+
+  /// 源标签：优先取标题括号里的平台名（聚合器常写成「剧名（腾讯视频）」），
+  /// 没有则退回后端源名。
+  String _sourceLabel(DanmakuAnime a) {
+    final m = RegExp(r'[（(\[【]([^）)\]】]+)[）)\]】]').firstMatch(a.animeTitle);
+    if (m != null) return m.group(1)!.trim();
+    return a.sourceName ?? a.animeTitle;
+  }
+
+  /// 归一化标题用于聚组：去掉括号内容（平台名等）与常见分隔符后比较。
+  String _normalizeTitle(String t) {
+    var s = t.replaceAll(RegExp(r'[（(\[【][^）)\]】]*[）)\]】]'), '');
+    s = s.replaceAll(RegExp(r'[\s·:：\-—_、,，.。!！?？]'), '');
+    return s.toLowerCase().trim();
+  }
+
+  /// 展示标题：把括号内的平台名折叠掉，保留可读主名。
+  String _baseTitle(String t) {
+    final s = t.replaceAll(RegExp(r'\s*[（(\[【][^）)\]】]*[）)\]】]\s*'), ' ').trim();
+    return s.isEmpty ? t : s;
+  }
+}
+
+bool _animeIsMovie(DanmakuAnime a) {
+  final t = a.type?.toLowerCase().trim();
+  if (t != null && t.isNotEmpty) return t == 'movie';
+  final ec = a.episodeCount ?? a.episodes?.length ?? 0;
+  return ec == 1;
+}
+
+/// 一部剧（或电影），可包含来自多个源的多个 anime 结果。
+class _DanmakuShow {
+  final String key;
+  final String title;
+  final List<DanmakuAnime> sources;
+
+  _DanmakuShow({
+    required this.key,
+    required this.title,
+    required this.sources,
+  });
+
+  /// 所有源都判定为电影才算电影（聚合器里偶有混入，从众取剧更安全）。
+  bool get isMovie => sources.isNotEmpty && sources.every(_animeIsMovie);
+}
+
+/// 归并后的「一集」：可能对应多个源的同一集。
+class _EpOption {
+  final String key;
+  final String? number;
+  final String label;
+  final List<_EpSource> sources;
+
+  _EpOption({
+    required this.key,
+    required this.number,
+    required this.label,
+    required this.sources,
+  });
+}
+
+class _EpSource {
+  final DanmakuAnime anime;
+  final DanmakuEpisode episode;
+  _EpSource({required this.anime, required this.episode});
 }


### PR DESCRIPTION
## 概述
桌面端体验优化一批 + 弹幕功能增强,落到三端。

## 改动
1. **桌面截图过曝修复**:media_kit 默认 `screenshot-raw video` 截的是 tone-map 前的 HDR 原始帧 → 改用 mpv `screenshot-to-file … window`(截渲染后窗口,与屏幕亮度一致),失败回退默认。
2. **三端播放键可视化进度条**:移动/桌面/TV 播放键底部叠观看进度填充 + 键内「继续观看 已看/总时长」。新增 `formatWatchedOverTotalLabel`/`formatTicksClock`/`watchedFraction` 三端共用。
3. **集详情页集列表上移**:选集/分集列表移到「简介(信息栏)」之上,方便切集(三端)。集封面经核实本就 16:9 横图、背景本就 backdrop,未改方向。
4. **弹幕本地导入**:新增 `DanmakuLocalParser`(.xml B站/弹弹 · .json · .ass),三端接入,解析后走 `loadedDanmakuProvider`,过滤/去重/渲染复用。
5. **弹幕搜索面板重构**:`searchAllStreamed` 流式分源(先到先显)+ 剧/电影区分(电影点即载、剧点进选集)+ 同剧多源按标题归组,单源直载、多源点集后展开源下拉。

## 验证
- `flutter analyze lib`:0 error,改动代码 0 新警告。
- `flutter test`:41 通过,1 既有 flaky(smoke test Timer-pending,非回归)。
- 待真机确认:HDR 片截图亮度;danmu_api/御坂 多源下拉。

🤖 Generated with [Claude Code](https://claude.com/claude-code)