### PR TITLE
fix(anirss/quark/security): Ani-rss 登录失效·夸克扫码二维码·移除泄露IP的 api-docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,8 @@ third_party/**/.dart_tool/
 third_party/**/build/
 third_party/**/.cxx/
 third_party/**/example/
+
+# Ani-rss API reference dumps (contain private server address — never commit)
+api-docs.json
+Swagger UI.html
+Swagger UI_files/

--- a/lib/core/sources/anirss/anirss_api.dart
+++ b/lib/core/sources/anirss/anirss_api.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import '../../providers/server_providers.dart';
 import '../source_http.dart';
 import 'anirss_token.dart';
@@ -138,11 +140,15 @@ class AniRssApi {
   }
 
   /// 同步构造 proxyImage URL（已有 token 时用，如详情 provider 预解析后）。
+  ///
+  /// 服务端 `ProxyImageController` 对 `imgUrl` 做 **Base64 解码**，故须先 base64 编码原始
+  /// 图片地址；鉴权用 `s=<登录令牌>` 走 Form 鉴权（URL 无法带 Authorization 头）。
   static String buildProxyImageUrl(
       ServerConfig server, String imgUrl, String token) {
     final base = normalizeBaseUrl(server.activeLineUrl);
+    final encoded = base64.encode(utf8.encode(imgUrl));
     return '$base/api/proxyImage'
-        '?imgUrl=${Uri.encodeQueryComponent(imgUrl)}'
-        '&${AniRssAuth.header}=${Uri.encodeQueryComponent(token)}';
+        '?imgUrl=${Uri.encodeQueryComponent(encoded)}'
+        '&${AniRssAuth.queryAuthKey}=${Uri.encodeQueryComponent(token)}';
   }
 }

--- a/lib/core/sources/anirss/anirss_token.dart
+++ b/lib/core/sources/anirss/anirss_token.dart
@@ -9,10 +9,15 @@ import '../source_http.dart';
 
 /// Ani-rss 鉴权 + 请求生命周期（三端、播放后端与类型化 API 共享一份 token 缓存）。
 ///
-/// 端点/字段以仓库根 `api-docs.json`（OpenAPI v3）为准：
-/// - 登录 `POST /api/login`，body `{username, password(MD5摘要)}` → `ResultString`（data=token）。
-/// - 鉴权 securityScheme 为 apiKey，**请求头 `api-key: <token>`**（非 Authorization）。
-/// - 失效（401/403）→ 清缓存、用账密重登一次。
+/// 端点/字段以仓库根 `api-docs.json`（OpenAPI v3）为准，但**鉴权以服务端源码为准**
+/// （ani-rss `AuthUtil`/`Header`/`Form`/`ApiKey`）：
+/// - 登录 `POST /api/login`，body `{username, password(MD5摘要)}` → `ResultString`
+///   （data=`sha256(json(login))` 登录令牌）。
+/// - 校验该登录令牌的方式有二：① 请求头 **`Authorization: <token>`**（`Header` 鉴权）；
+///   ② 查询参数 **`s=<token>`**（`Form` 鉴权，用于无法设请求头的流/图片 URL）。
+///   swagger 里的 `api-key` 头是**另一套**「静态 Config.apiKey」鉴权，与登录令牌无关，
+///   我们没有那个静态 key，故**绝不能**把登录令牌塞进 `api-key` 头（否则恒判失败→「登录已失效」）。
+/// - 失效（服务端返回 `{code:403, message:'登录已失效'}`）→ 清缓存、用账密重登一次。
 ///
 /// 单例：[AniRssAuth.instance]。`AniRssBackend`（播放路径）与 `AniRssApi`（浏览/订阅/
 /// 设置）都依赖它，故任一路径触发的重登都会刷新另一路径使用的 token。
@@ -20,8 +25,11 @@ class AniRssAuth {
   AniRssAuth._();
   static final AniRssAuth instance = AniRssAuth._();
 
-  /// 鉴权请求头名（OpenAPI: name=api-key, in=header）。
-  static const String header = 'api-key';
+  /// 登录令牌的鉴权请求头名（服务端 `Header` 鉴权读 `Authorization`）。
+  static const String header = 'Authorization';
+
+  /// 登录令牌的查询参数名（服务端 `Form` 鉴权读 `s`；用于流/图片 URL）。
+  static const String queryAuthKey = 's';
 
   final Map<String, String> _tokenCache = {};
 
@@ -82,7 +90,7 @@ class AniRssAuth {
   Dio _dio(ServerConfig server) =>
       buildSourceDio(baseUrl: normalizeBaseUrl(server.activeLineUrl));
 
-  /// 发起一个带 api-key 头的鉴权请求；失效自动重登一次。
+  /// 发起一个带 `Authorization` 登录令牌头的鉴权请求；失效自动重登一次。
   /// [method] 默认 POST（ani-rss 绝大多数接口都是 POST）。
   Future<Response> authed(
     ServerConfig server,

--- a/lib/core/sources/anirss_backend.dart
+++ b/lib/core/sources/anirss_backend.dart
@@ -105,9 +105,10 @@ class AniRssBackend implements MediaSourceBackend {
     final token = await _auth.ensureToken(server);
     final base = normalizeBaseUrl(server.activeLineUrl);
     // filename 已是 base64，仅做查询参数转义，不可二次 base64。
+    // URL 无法带请求头 → 用 `s=<token>` 查询参数走服务端 Form 鉴权（非 api-key）。
     final url = '$base/api/file'
         '?filename=${Uri.encodeQueryComponent(b64Filename)}'
-        '&${AniRssAuth.header}=${Uri.encodeQueryComponent(token)}';
+        '&${AniRssAuth.queryAuthKey}=${Uri.encodeQueryComponent(token)}';
     final headers = {AniRssAuth.header: token};
     return ResolvedPlay(
       url: url,
@@ -136,7 +137,7 @@ class AniRssBackend implements MediaSourceBackend {
           : '$base${u.startsWith('/') ? '' : '/'}$u';
       final sep = full.contains('?') ? '&' : '?';
       subs.add(SourceSubtitle(
-        url: '$full$sep${AniRssAuth.header}=${Uri.encodeQueryComponent(token)}',
+        url: '$full$sep${AniRssAuth.queryAuthKey}=${Uri.encodeQueryComponent(token)}',
         title: s['name']?.toString(),
         httpHeaders: headers,
       ));

--- a/lib/ui/screens/source/quark_qr_login_view.dart
+++ b/lib/ui/screens/source/quark_qr_login_view.dart
@@ -1,3 +1,6 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
 import 'package:flutter/material.dart';
 import 'package:qr_flutter/qr_flutter.dart';
 
@@ -108,12 +111,7 @@ class _QuarkQrLoginViewState extends State<QuarkQrLoginView> {
         return Container(
           padding: const EdgeInsets.all(8),
           color: Colors.white,
-          child: QrImageView(
-            data: login.qrData ?? '',
-            version: QrVersions.auto,
-            size: 200,
-            backgroundColor: Colors.white,
-          ),
+          child: _qrContent(login.qrData ?? ''),
         );
       case QuarkQrState.success:
         return const Icon(Icons.check_circle, color: Colors.green, size: 64);
@@ -124,6 +122,57 @@ class _QuarkQrLoginViewState extends State<QuarkQrLoginView> {
       case QuarkQrState.loading:
         return const CircularProgressIndicator();
     }
+  }
+
+  /// 夸克 TV 的 `qr_data` 实际是**二维码 PNG 图片的 base64**（或 data URI），
+  /// 不是待编码文本——直接当图片显示；只有在确实是普通文本/URL 时才回退 [QrImageView]。
+  Widget _qrContent(String qrData) {
+    final bytes = _tryDecodeImage(qrData);
+    if (bytes != null) {
+      return Image.memory(
+        bytes,
+        width: 200,
+        height: 200,
+        fit: BoxFit.contain,
+        gaplessPlayback: true,
+        errorBuilder: (_, __, ___) => _qrFromText(qrData),
+      );
+    }
+    return _qrFromText(qrData);
+  }
+
+  Widget _qrFromText(String text) => QrImageView(
+        data: text,
+        version: QrVersions.auto,
+        size: 200,
+        backgroundColor: Colors.white,
+      );
+
+  /// 尝试把 [qrData] 解析为图片字节（data URI 前缀或裸 base64 的 PNG/JPEG/GIF）。
+  /// 解析不出图片签名则返回 null（说明是普通文本/URL）。
+  Uint8List? _tryDecodeImage(String qrData) {
+    var s = qrData.trim();
+    if (s.isEmpty) return null;
+    final comma = s.indexOf(',');
+    if (s.startsWith('data:image') && comma > 0) {
+      s = s.substring(comma + 1);
+    }
+    try {
+      final bytes = base64.decode(base64.normalize(s));
+      if (_looksLikeImage(bytes)) return bytes;
+    } catch (_) {}
+    return null;
+  }
+
+  bool _looksLikeImage(Uint8List b) {
+    if (b.length < 4) return false;
+    // PNG 89 50 4E 47
+    if (b[0] == 0x89 && b[1] == 0x50 && b[2] == 0x4E && b[3] == 0x47) return true;
+    // JPEG FF D8 FF
+    if (b[0] == 0xFF && b[1] == 0xD8 && b[2] == 0xFF) return true;
+    // GIF 47 49 46
+    if (b[0] == 0x47 && b[1] == 0x49 && b[2] == 0x46) return true;
+    return false;
   }
 
   String _statusText(QuarkQrState state) {


### PR DESCRIPTION
真机测试发现的三个问题修复：

## 1. Ani-rss「登录了却说登录失效」
**根因**（核对 ani-rss 服务端源码 `AuthUtil`/`Header`/`Form`/`ApiKey`）：登录返回的令牌 `sha256(json(login))` 必须走 `Authorization` 请求头（Header 鉴权）或 `s=` 查询参数（Form 鉴权）。swagger 里的 `api-key` 头是**另一套静态 `Config.apiKey`**，我们没有那个 key——塞登录令牌进 `api-key` 头会恒判失败，服务端返回 `{code:403,message:"登录已失效"}`。
- `anirss_token.dart`：`header` 改 `Authorization`，新增 `queryAuthKey='s'`
- `anirss_backend.dart`：取流/字幕 URL 鉴权改 `s=` 参数
- `anirss_api.dart`：`proxyImage` 的 `imgUrl` 须先 base64 编码（服务端会解码），鉴权改 `s=`

## 2. 夸克 TV 扫码二维码不显示
`/oauth/authorize` 的 `qr_data` 实测是**二维码 PNG 图片的 base64**（`iVBOR…`，~4868 字符），不是待编码文本。原先喂给 `QrImageView` 再编码 → 超 QR 容量 → 不渲染。改为检测图片签名（PNG/JPEG/GIF + data URI）后 `Image.memory` 直接显示，仅普通文本/URL 才回退 `QrImageView`。三端共用此 view，三端同修。

本地 `flutter analyze` 改动文件零告警。

🤖 Generated with [Claude Code](https://claude.com/claude-code)